### PR TITLE
feat: add main menu GUI and pause menu with settings panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,4 @@ ffmpeg
 tracy
 Makefile
 /*.sln
+assets/saves/savedata.xml

--- a/include/Scene.h
+++ b/include/Scene.h
@@ -1,96 +1,109 @@
 #pragma once
-
 #include "Module.h"
 #include "Player.h"
-#include "UIButton.h"
+#include "UIManager.h"
+#include "UIElement.h"
 
-struct SDL_Texture;
-
-enum class SceneID
-{
-	MAIN_MENU,
-	INTRO_CINEMATIC,
-	GAMEPLAY
+enum class SceneID {
+    MAIN_MENU,
+    INTRO_CINEMATIC,
+    GAMEPLAY
 };
-
 
 class Scene : public Module
 {
 public:
+    Scene();
+    ~Scene();
 
-	Scene();
+    bool Awake()          override;
+    bool Start()          override;
+    bool PreUpdate()      override;
+    bool Update(float dt) override;
+    bool PostUpdate()     override;
+    bool CleanUp()        override;
 
-	// Destructor
-	virtual ~Scene();
+    bool OnUIMouseClickEvent(UIElement* uiElement);
 
-	// Called before render is available
-	bool Awake();
+    Vector2D GetPlayerPosition();
+    void     SetPlayerPosition(Vector2D pos);
+    SceneID  GetCurrentScene() const { return currentScene; }
+    std::string GetTilePosDebug() const { return ""; }
 
-	// Called before the first frame
-	bool Start();
-
-	// Called before all Updates
-	bool PreUpdate();
-
-	// Called each loop iteration
-	bool Update(float dt);
-
-	// Called before all Updates
-	bool PostUpdate();
-
-	// Called before quitting
-	bool CleanUp();
-
-	// Return the player position
-	Vector2D GetPlayerPosition();
-
-	// Set the player position
-	void SetPlayerPosition(Vector2D pos);
-
-	// Get current scene ID
-	SceneID GetCurrentScene() const { return currentScene; }
-
-	// Get tilePosDebug value
-	std::string GetTilePosDebug() {
-		return tilePosDebug;
-	}
-
-	// Handles multiple Gui Event methods
-	bool OnUIMouseClickEvent(UIElement* uiElement);
-
-	void ChangeScene(SceneID newScene);
-	void UnloadCurrentScene();
-	void LoadScene(SceneID newScene);
+    std::shared_ptr<Player> player = nullptr;
 
 private:
+    // ?? Scene routing ?????????????????????????????????????????????????????????
+    SceneID currentScene = SceneID::MAIN_MENU;
+    bool    hasPendingSceneChange = false;
+    SceneID pendingScene = SceneID::MAIN_MENU;
 
-	void LoadMainMenu();
-	void UnloadMainMenu();
-	void UpdateMainMenu(float dt);
-	void HandleMainMenuUIEvents(UIElement* uiElement);
+    void LoadScene(SceneID s);
+    void ChangeScene(SceneID s);
+    void UnloadCurrentScene();
 
-	void LoadIntroCinematic();
-	void UnloadIntroCinematic();
-	void UpdateIntroCinematic(float dt);
+    // ?? Shared volume state (main menu + pause) ????????????????????????????????
+    float musicVolume_ = 0.8f;
+    float sfxVolume_ = 0.8f;
 
-	void LoadGameplay();
-	void UnloadGameplay();
-	void UpdateGameplay(float dt);
-	void PostUpdateGameplay();
+    // ????????????????????????????????????????????????????????????????????????
+    //  MAIN MENU
+    // ????????????????????????????????????????????????????????????????????????
+    bool showSettings_ = false;
+    int  settingsCooldown_ = 0;
 
-private:
+    void LoadMainMenu();
+    void UnloadMainMenu();
+    void UpdateMainMenu(float dt);
+    void PostUpdateMainMenu();
+    void HandleMainMenuUIEvents(UIElement* uiElement);
+    void DrawSettingsPanel(int winW, int winH);
+    void SetSettingsPanelVisible(bool visible);
 
-	std::shared_ptr<Player> player;
-	SDL_Texture* mouseTileTex = nullptr;
-	std::string tilePosDebug = "[0,0]";
-	bool once = false;
+    // Button IDs – main menu
+    static constexpr int BTN_PLAY = 1;
+    static constexpr int BTN_SETTINGS = 2;
+    static constexpr int BTN_EXIT = 3;
+    static constexpr int BTN_SETTINGS_BACK = 10;
+    static constexpr int BTN_MUSIC_UP = 11;
+    static constexpr int BTN_MUSIC_DOWN = 12;
+    static constexpr int BTN_SFX_UP = 13;
+    static constexpr int BTN_SFX_DOWN = 14;
 
-	std::shared_ptr<UIButton> uiBt;
-	float volume = 1.0;
+    // ????????????????????????????????????????????????????????????????????????
+    //  INTRO CINEMATIC
+    // ????????????????????????????????????????????????????????????????????????
+    void LoadIntroCinematic();
+    void UnloadIntroCinematic();
+    void UpdateIntroCinematic(float dt);
 
-	SceneID currentScene = SceneID::MAIN_MENU;
+    // ????????????????????????????????????????????????????????????????????????
+    //  GAMEPLAY + PAUSE MENU
+    // ????????????????????????????????????????????????????????????????????????
+    bool isPaused_ = false;
+    bool showPauseOptions_ = false;
 
-	// Deferred scene change to avoid use-after-free when called from UI callbacks
-	bool hasPendingSceneChange = false;
-	SceneID pendingScene = SceneID::MAIN_MENU;
+    void LoadGameplay();
+    void UnloadGameplay();
+    void UpdateGameplay(float dt);
+    void PostUpdateGameplay();
+
+    void LoadPauseMenuButtons();
+    void SetPauseMenuVisible(bool visible);
+    void SetPauseOptionsPanelVisible(bool visible);
+    void DrawPauseMenu();
+    void DrawPauseOptionsPanel(int winW, int winH);
+    void HandlePauseMenuUIEvents(UIElement* uiElement);
+
+    // Button IDs – pause menu
+    static constexpr int BTN_PAUSE_CONTINUE = 20;
+    static constexpr int BTN_PAUSE_OPTIONS = 21;
+    static constexpr int BTN_PAUSE_SAVE = 22;
+    static constexpr int BTN_PAUSE_MAINMENU = 23;
+    static constexpr int BTN_PAUSE_QUIT = 24;
+    static constexpr int BTN_PAUSE_OPT_MUSIC_UP = 25;
+    static constexpr int BTN_PAUSE_OPT_MUSIC_DOWN = 26;
+    static constexpr int BTN_PAUSE_OPT_SFX_UP = 27;
+    static constexpr int BTN_PAUSE_OPT_SFX_DOWN = 28;
+    static constexpr int BTN_PAUSE_OPT_BACK = 29;
 };

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -286,6 +286,7 @@ bool Render::DrawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uin
 }
 
 // Draw text on screen using SDL3_ttf
+// FIX: applies window scale so text aligns correctly with DrawRectangle elements
 bool Render::DrawText(const char* text, int x, int y, int w, int h, SDL_Color color) const
 {
 	if (!font || !renderer || !text) {
@@ -293,15 +294,14 @@ bool Render::DrawText(const char* text, int x, int y, int w, int h, SDL_Color co
 		return false;
 	}
 
-	// Render the text to a surface
-	// SDL3_ttf: length can be 0 for null-terminated strings
+	int scale = Engine::GetInstance().window->GetScale();
+
 	SDL_Surface* surface = TTF_RenderText_Solid(font, text, 0, color);
 	if (!surface) {
 		LOG("DrawText: TTF_RenderText_Solid failed: %s", SDL_GetError());
 		return false;
 	}
 
-	// Create a texture from the surface
 	SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
 	if (!texture) {
 		LOG("DrawText: SDL_CreateTextureFromSurface failed: %s", SDL_GetError());
@@ -309,21 +309,21 @@ bool Render::DrawText(const char* text, int x, int y, int w, int h, SDL_Color co
 		return false;
 	}
 
-	// Optional but often needed when using alpha/text
 	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
 
-	// If w/h are 0, use the text’s natural size
-	float fw = (w > 0) ? (float)w : (float)surface->w;
-	float fh = (h > 0) ? (float)h : (float)surface->h;
+	// Apply scale to position and size — same convention as DrawRectangle (use_camera=false)
+	float fx = (float)(x * scale);
+	float fy = (float)(y * scale);
+	// If caller passes explicit size, scale it; otherwise use natural surface size (sharp)
+	float fw = (w > 0) ? (float)(w * scale) : (float)(surface->w);
+	float fh = (h > 0) ? (float)(h * scale) : (float)(surface->h);
 
-	SDL_FRect dstrect = { (float)x, (float)y, fw, fh };
+	SDL_FRect dstrect = { fx, fy, fw, fh };
 
-	// Render the texture to the current render target
 	if (!SDL_RenderTexture(renderer, texture, nullptr, &dstrect)) {
 		LOG("DrawText: SDL_RenderTexture failed: %s", SDL_GetError());
 	}
 
-	// Cleanup
 	SDL_DestroyTexture(texture);
 	SDL_DestroySurface(surface);
 
@@ -338,7 +338,6 @@ bool Render::IsOnScreenWorldRect(float x, float y, float w, float h, int margin)
 	float screenW = static_cast<float>(camera.w);
 	float screenH = static_cast<float>(camera.h);
 
-	// Check if rect is outside the camera viewport (with margin)
 	if (x + w + margin < camX) return false;
 	if (x - margin > camX + screenW) return false;
 	if (y + h + margin < camY) return false;
@@ -353,7 +352,6 @@ void Render::SetCameraTarget(float x, float y)
 	cameraTargetX_ = x;
 	cameraTargetY_ = y;
 
-	// On first call, snap camera to target immediately (no lerp)
 	if (!cameraInitialized_)
 	{
 		float viewW = GetWorldViewportWidth();
@@ -367,120 +365,77 @@ void Render::SetCameraTarget(float x, float y)
 // Smooth follow using lerp with dead zones
 void Render::FollowTarget(float dt)
 {
-	// Get world-space viewport dimensions (accounts for window scale)
 	float viewW = GetWorldViewportWidth();
 	float viewH = GetWorldViewportHeight();
 
-	// Current camera center in world space
 	float currentX = -camera.x + viewW / 2.0f;
 	float currentY = -camera.y + viewH / 2.0f;
 
-	// Target position (center of screen should be here)
 	float targetX = cameraTargetX_;
 	float targetY = cameraTargetY_;
 
-	// Dead zone check - only move camera if target is outside dead zone
 	float deltaX = targetX - currentX;
 	float deltaY = targetY - currentY;
 
-	// Apply dead zone - if within dead zone, don't move
 	if (std::abs(deltaX) <= deadZoneWidth_)
-	{
 		targetX = currentX;
-	}
 	else
-	{
-		// Reduce delta by dead zone size (camera follows outside dead zone)
 		targetX = currentX + (deltaX > 0 ? deltaX - deadZoneWidth_ : deltaX + deadZoneWidth_);
-	}
 
 	if (std::abs(deltaY) <= deadZoneHeight_)
-	{
 		targetY = currentY;
-	}
 	else
-	{
 		targetY = currentY + (deltaY > 0 ? deltaY - deadZoneHeight_ : deltaY + deadZoneHeight_);
-	}
 
-	// Lerp towards target position
 	float lerpFactor = 1.0f - std::exp(-cameraSmoothSpeed_ * dt / 1000.0f);
 	float newX = currentX + (targetX - currentX) * lerpFactor;
 	float newY = currentY + (targetY - currentY) * lerpFactor;
 
-	// Convert back to camera coordinates (negative because camera offset is inverted)
 	camera.x = static_cast<int>(-(newX - viewW / 2.0f));
 	camera.y = static_cast<int>(-(newY - viewH / 2.0f));
 }
 
-// Camera System - Issue #21: Set camera position directly (for cutscenes, etc.)
 void Render::SetCameraPosition(float x, float y)
 {
 	float viewW = GetWorldViewportWidth();
 	float viewH = GetWorldViewportHeight();
 	camera.x = static_cast<int>(-x + viewW / 2);
 	camera.y = static_cast<int>(-y + viewH / 2);
-
-	// Keep internal camera follow state in sync with the direct position
 	cameraTargetX_ = x;
 	cameraTargetY_ = y;
 	cameraInitialized_ = true;
 }
 
-// Camera System - Issue #21: Clamp camera to map boundaries
 void Render::ClampCameraToMapBounds(float mapWidth, float mapHeight)
 {
-	// Get world-space viewport dimensions (accounts for window scale)
 	float viewW = GetWorldViewportWidth();
 	float viewH = GetWorldViewportHeight();
 
-	// Camera X bounds
-	if (camera.x > 0)
-	{
-		camera.x = 0;  // Left edge
-	}
+	if (camera.x > 0) camera.x = 0;
 	if (camera.x < -(mapWidth - viewW))
-	{
-		camera.x = static_cast<int>(-(mapWidth - viewW));  // Right edge
-	}
+		camera.x = static_cast<int>(-(mapWidth - viewW));
 
-	// Camera Y bounds
-	if (camera.y > 0)
-	{
-		camera.y = 0;  // Top edge
-	}
+	if (camera.y > 0) camera.y = 0;
 	if (camera.y < -(mapHeight - viewH))
-	{
-		camera.y = static_cast<int>(-(mapHeight - viewH));  // Bottom edge
-	}
+		camera.y = static_cast<int>(-(mapHeight - viewH));
 
-	// Handle edge case where map is smaller than camera
 	if (mapWidth < viewW)
-	{
 		camera.x = static_cast<int>((viewW - mapWidth) / 2.0f);
-	}
 	if (mapHeight < viewH)
-	{
 		camera.y = static_cast<int>((viewH - mapHeight) / 2.0f);
-	}
 }
 
-// Camera System - Issue #21: Set dead zone size
 void Render::SetDeadZone(float width, float height)
 {
-	// Clamp dead zone dimensions to non-negative values
 	deadZoneWidth_ = std::fmax(0.0f, width);
 	deadZoneHeight_ = std::fmax(0.0f, height);
 }
 
-// Camera System - Issue #21: Set camera follow speed
 void Render::SetCameraSmoothSpeed(float speed)
 {
-	// Clamp camera smooth speed to non-negative values
 	cameraSmoothSpeed_ = std::fmax(0.0f, speed);
 }
 
-// Camera System - Issue #21: Get current camera center position in world space
 Vector2D Render::GetCameraPosition() const
 {
 	float viewW = GetWorldViewportWidth();
@@ -491,18 +446,14 @@ Vector2D Render::GetCameraPosition() const
 	);
 }
 
-// Camera System: Get world-space viewport width (accounts for window scale)
 float Render::GetWorldViewportWidth() const
 {
 	int scale = Engine::GetInstance().window->GetScale();
 	return static_cast<float>(camera.w) / scale;
 }
 
-// Camera System: Get world-space viewport height (accounts for window scale)
 float Render::GetWorldViewportHeight() const
 {
 	int scale = Engine::GetInstance().window->GetScale();
 	return static_cast<float>(camera.h) / scale;
 }
-
-

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -16,13 +16,25 @@
 #include "UIManager.h"
 #include "SaveSystem.h"
 
+// ────────────────────────────────────────────────────────────────────────────
+// Button IDs  (main menu)
+// ────────────────────────────────────────────────────────────────────────────
+static constexpr int BTN_PLAY = 1;
+static constexpr int BTN_SETTINGS = 2;
+static constexpr int BTN_EXIT = 3;
+// Settings panel
+static constexpr int BTN_SETTINGS_BACK = 10;
+static constexpr int BTN_MUSIC_UP = 11;
+static constexpr int BTN_MUSIC_DOWN = 12;
+static constexpr int BTN_SFX_UP = 13;
+static constexpr int BTN_SFX_DOWN = 14;
+
 Scene::Scene() : Module()
 {
 	name = "scene";
 }
 
-Scene::~Scene()
-{}
+Scene::~Scene() {}
 
 bool Scene::Awake()
 {
@@ -31,19 +43,11 @@ bool Scene::Awake()
 	return true;
 }
 
-bool Scene::Start()
-{
-	return true;
-}
-
-bool Scene::PreUpdate()
-{
-	return true;
-}
+bool Scene::Start() { return true; }
+bool Scene::PreUpdate() { return true; }
 
 bool Scene::Update(float dt)
 {
-	// Apply deferred scene change (safe here, outside UI callbacks)
 	if (hasPendingSceneChange) {
 		hasPendingSceneChange = false;
 		ChangeScene(pendingScene);
@@ -52,6 +56,9 @@ bool Scene::Update(float dt)
 	switch (currentScene)
 	{
 	case SceneID::MAIN_MENU:
+		// Draw background FIRST (Scene runs before UIManager in module list,
+		// so buttons will render on top in UIManager::Update)
+		PostUpdateMainMenu();
 		UpdateMainMenu(dt);
 		break;
 	case SceneID::INTRO_CINEMATIC:
@@ -61,7 +68,6 @@ bool Scene::Update(float dt)
 		UpdateGameplay(dt);
 		break;
 	}
-
 	return true;
 }
 
@@ -71,17 +77,12 @@ bool Scene::PostUpdate()
 
 	switch (currentScene)
 	{
-	case SceneID::MAIN_MENU:
-		break;
-	case SceneID::INTRO_CINEMATIC:
-		break;
 	case SceneID::GAMEPLAY:
 		PostUpdateGameplay();
 		break;
+	default:
+		break;
 	}
-
-	if(Engine::GetInstance().input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
-		ret = false;
 
 	return ret;
 }
@@ -94,9 +95,11 @@ bool Scene::OnUIMouseClickEvent(UIElement* uiElement)
 		HandleMainMenuUIEvents(uiElement);
 		break;
 	case SceneID::GAMEPLAY:
+		HandlePauseMenuUIEvents(uiElement);
+		break;
+	default:
 		break;
 	}
-
 	return true;
 }
 
@@ -110,7 +113,7 @@ bool Scene::CleanUp()
 Vector2D Scene::GetPlayerPosition()
 {
 	if (player) return player->GetPosition();
-	else return Vector2D(0,0);
+	return Vector2D(0, 0);
 }
 
 void Scene::SetPlayerPosition(Vector2D pos)
@@ -118,149 +121,593 @@ void Scene::SetPlayerPosition(Vector2D pos)
 	if (player) player->SetPosition(pos);
 }
 
-// *********************************************
-// Scene change functions
-// *********************************************
+// ============================================================================
+//  Scene routing
+// ============================================================================
 
-void Scene::LoadScene(SceneID newScene)
+void Scene::LoadScene(SceneID s)
 {
-	switch (newScene)
+	switch (s)
 	{
-	case SceneID::MAIN_MENU:
-		LoadMainMenu();
-		break;
-	case SceneID::INTRO_CINEMATIC:
-		LoadIntroCinematic();
-		break;
-	case SceneID::GAMEPLAY:
-		LoadGameplay();
-		break;
+	case SceneID::MAIN_MENU:       LoadMainMenu();       break;
+	case SceneID::INTRO_CINEMATIC: LoadIntroCinematic(); break;
+	case SceneID::GAMEPLAY:        LoadGameplay();        break;
 	}
 }
 
-void Scene::ChangeScene(SceneID newScene)
+void Scene::ChangeScene(SceneID s)
 {
 	UnloadCurrentScene();
-	currentScene = newScene;
+	currentScene = s;
 	LoadScene(currentScene);
 }
 
-void Scene::UnloadCurrentScene() {
-
+void Scene::UnloadCurrentScene()
+{
 	switch (currentScene)
 	{
-	case SceneID::MAIN_MENU:
-		UnloadMainMenu();
-		break;
-	case SceneID::INTRO_CINEMATIC:
-		UnloadIntroCinematic();
-		break;
-	case SceneID::GAMEPLAY:
-		UnloadGameplay();
-		break;
+	case SceneID::MAIN_MENU:       UnloadMainMenu();       break;
+	case SceneID::INTRO_CINEMATIC: UnloadIntroCinematic(); break;
+	case SceneID::GAMEPLAY:        UnloadGameplay();        break;
 	}
 }
 
-// *********************************************
-// MAIN MENU
-// *********************************************
+// ============================================================================
+//  MAIN MENU
+// ============================================================================
 
-void Scene::LoadMainMenu() {
+void Scene::LoadMainMenu()
+{
+	showSettings_ = false;
+	settingsCooldown_ = 0;
+	musicVolume_ = 0.8f;
+	sfxVolume_ = 0.8f;
 
-	// Create a "Play" button centered on screen
-	SDL_Rect btPos = { 580, 350, 120, 30 };
-	std::dynamic_pointer_cast<UIButton>(Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, 1, "Play", btPos, this));
+	int winW = 0, winH = 0;
+	Engine::GetInstance().window->GetWindowSize(winW, winH);
+
+	const int btnW = 220;
+	const int btnH = 42;
+	const int btnX = winW / 2 - btnW / 2;
+	const int startY = winH / 2 - 20;
+	const int gap = 58;
+
+	SDL_Rect playPos = { btnX, startY,         btnW, btnH };
+	SDL_Rect settingsPos = { btnX, startY + gap,    btnW, btnH };
+	SDL_Rect exitPos = { btnX, startY + gap * 2,  btnW, btnH };
+
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PLAY, "PLAY", playPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_SETTINGS, "SETTINGS", settingsPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_EXIT, "EXIT", exitPos, this);
+
+	// Settings panel — placed in the TOP half so BACK never overlaps main buttons
+	const int panelW = 340;
+	const int panelX = winW / 2 - panelW / 2;
+	const int panelY = 60;          // always near top, away from main buttons
+	const int smallBtnW = 40;
+	const int smallBtnH = 34;
+	const int rowH = 52;
+
+	SDL_Rect musicUpPos = { panelX + panelW - smallBtnW - 12, panelY + 60,              smallBtnW, smallBtnH };
+	SDL_Rect musicDownPos = { panelX + 12,                       panelY + 60,              smallBtnW, smallBtnH };
+	SDL_Rect sfxUpPos = { panelX + panelW - smallBtnW - 12, panelY + 60 + rowH,       smallBtnW, smallBtnH };
+	SDL_Rect sfxDownPos = { panelX + 12,                       panelY + 60 + rowH,       smallBtnW, smallBtnH };
+	SDL_Rect backPos = { panelX + panelW / 2 - 60,            panelY + 60 + rowH * 2 + 10, 120, btnH };
+
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_MUSIC_UP, "+", musicUpPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_MUSIC_DOWN, "-", musicDownPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_SFX_UP, "+", sfxUpPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_SFX_DOWN, "-", sfxDownPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_SETTINGS_BACK, "BACK", backPos, this);
+
+	SetSettingsPanelVisible(false);
 }
 
-void Scene::UnloadMainMenu() {
-	Engine::GetInstance().uiManager->CleanUp();	
+void Scene::UnloadMainMenu()
+{
+	Engine::GetInstance().uiManager->CleanUp();
 }
 
-void Scene::UpdateMainMenu(float dt) {}
+void Scene::UpdateMainMenu(float dt)
+{
+	// Decrement cooldown each frame
+	if (settingsCooldown_ > 0) settingsCooldown_--;
+
+	// ESC closes settings
+	if (showSettings_ && Engine::GetInstance().input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
+	{
+		showSettings_ = false;
+		SetSettingsPanelVisible(false);
+	}
+}
+
+void Scene::PostUpdateMainMenu()
+{
+	auto& render = *Engine::GetInstance().render;
+	int winW = 0, winH = 0;
+	Engine::GetInstance().window->GetWindowSize(winW, winH);
+
+	// ── Background ───────────────────────────────────────────────────────────
+	SDL_Rect bg = { 0, 0, winW, winH };
+	render.DrawRectangle(bg, 5, 8, 18, 255, true, false);
+
+	// Decorative horizontal scanlines (subtle)
+	for (int y = 0; y < winH; y += 4)
+	{
+		SDL_Rect line = { 0, y, winW, 1 };
+		render.DrawRectangle(line, 255, 255, 255, 6, true, false);
+	}
+
+	// Left vertical accent strip
+	SDL_Rect strip = { 0, 0, 5, winH };
+	render.DrawRectangle(strip, 80, 140, 200, 200, true, false);
+
+	// ── Title ────────────────────────────────────────────────────────────────
+	// Font is 25px — draw title at natural size (no stretching = sharp)
+	const int titleX = winW / 2 - 130;
+	const int titleY = winH / 4 - 13;
+
+	// Title shadow
+	render.DrawText("ECHOES OF SLUMBERS", titleX + 2, titleY + 2, 0, 0, { 0, 0, 0, 200 });
+	// Title glow
+	render.DrawText("ECHOES OF SLUMBERS", titleX - 1, titleY - 1, 0, 0, { 80, 140, 200, 70 });
+	// Title main
+	render.DrawText("ECHOES OF SLUMBERS", titleX, titleY, 0, 0, { 200, 220, 255, 255 });
+
+	// Subtitle (natural size, centred approximately)
+	render.DrawText("HIDDEN DREAM STUDIOS", winW / 2 - 115, titleY + 32, 0, 0, { 80, 110, 160, 200 });
+
+	// Decorative line under title
+	render.DrawLine(winW / 2 - 160, titleY + 56, winW / 2 + 160, titleY + 56,
+		80, 130, 190, 160, false);
+
+	// ── Settings Panel (drawn before UI buttons so buttons render on top) ───
+	if (showSettings_)
+	{
+		DrawSettingsPanel(winW, winH);
+	}
+}
+
+void Scene::DrawSettingsPanel(int winW, int winH)
+{
+	auto& render = *Engine::GetInstance().render;
+
+	const int panelW = 340;
+	const int panelH = 240;
+	const int panelX = winW / 2 - panelW / 2;
+	const int panelY = 60;          // matches LoadMainMenu button positions
+	const int rowH = 52;
+
+	// Dim overlay
+	SDL_Rect overlay = { 0, 0, winW, winH };
+	render.DrawRectangle(overlay, 0, 0, 0, 160, true, false);
+
+	// Panel background
+	SDL_Rect panel = { panelX, panelY, panelW, panelH };
+	render.DrawRectangle(panel, 10, 14, 28, 245, true, false);
+	// Panel border
+	render.DrawRectangle(panel, 80, 120, 180, 200, false, false);
+	// Top accent
+	SDL_Rect topBar = { panelX, panelY, panelW, 4 };
+	render.DrawRectangle(topBar, 80, 140, 200, 255, true, false);
+
+	// Title
+	render.DrawText("SETTINGS", panelX + panelW / 2 - 44, panelY + 14, 0, 0,
+		{ 180, 210, 240, 255 });
+
+	// ── Music volume row ─────────────────────────────────────────────────────
+	render.DrawText("MUSIC", panelX + 60, panelY + 66, 0, 0, { 150, 180, 210, 220 });
+
+	// Volume bar background
+	SDL_Rect barBg = { panelX + 60, panelY + 86, panelW - 120, 8 };
+	render.DrawRectangle(barBg, 30, 40, 60, 200, true, false);
+	// Volume bar fill
+	int musicFill = (int)((panelW - 120) * musicVolume_);
+	SDL_Rect barFill = { panelX + 60, panelY + 86, musicFill, 8 };
+	render.DrawRectangle(barFill, 80, 160, 220, 255, true, false);
+
+	// Value text
+	char volText[8];
+	snprintf(volText, sizeof(volText), "%d%%", (int)(musicVolume_ * 100));
+	render.DrawText(volText, panelX + panelW / 2 - 15, panelY + 60, 0, 0,
+		{ 200, 220, 240, 255 });
+
+	// ── SFX volume row ───────────────────────────────────────────────────────
+	render.DrawText("SFX", panelX + 60, panelY + 66 + rowH, 0, 0, { 150, 180, 210, 220 });
+
+	SDL_Rect sfxBarBg = { panelX + 60, panelY + 86 + rowH, panelW - 120, 8 };
+	render.DrawRectangle(sfxBarBg, 30, 40, 60, 200, true, false);
+	int sfxFill = (int)((panelW - 120) * sfxVolume_);
+	SDL_Rect sfxBarFill = { panelX + 60, panelY + 86 + rowH, sfxFill, 8 };
+	render.DrawRectangle(sfxBarFill, 80, 160, 220, 255, true, false);
+
+	snprintf(volText, sizeof(volText), "%d%%", (int)(sfxVolume_ * 100));
+	render.DrawText(volText, panelX + panelW / 2 - 15, panelY + 60 + rowH, 0, 0,
+		{ 200, 220, 240, 255 });
+}
 
 void Scene::HandleMainMenuUIEvents(UIElement* uiElement)
 {
+	// Ignore events during cooldown (prevents settings panel from instantly closing)
+	if (settingsCooldown_ > 0) return;
+
 	switch (uiElement->id)
 	{
-	case 1: // Play button
-		LOG("Main Menu: Play clicked!");
+		// ── Main buttons ─────────────────────────────────────────────────────────
+	case BTN_PLAY:
+		LOG("Main Menu: Play");
 		hasPendingSceneChange = true;
 		pendingScene = SceneID::INTRO_CINEMATIC;
 		break;
+
+	case BTN_SETTINGS:
+		showSettings_ = !showSettings_;
+		SetSettingsPanelVisible(showSettings_);
+		settingsCooldown_ = 4;   // ignore events for 4 frames after opening
+		break;
+
+	case BTN_EXIT:
+		LOG("Main Menu: Exit");
+		// Signal engine to quit via window event
+		SDL_Event quitEvent;
+		quitEvent.type = SDL_EVENT_QUIT;
+		SDL_PushEvent(&quitEvent);
+		break;
+
+		// ── Settings buttons ─────────────────────────────────────────────────────
+	case BTN_MUSIC_UP:
+		musicVolume_ = std::min(1.0f, musicVolume_ + 0.1f);
+		Engine::GetInstance().audio->SetMusicVolume(musicVolume_);
+		break;
+
+	case BTN_MUSIC_DOWN:
+		musicVolume_ = std::max(0.0f, musicVolume_ - 0.1f);
+		Engine::GetInstance().audio->SetMusicVolume(musicVolume_);
+		break;
+
+	case BTN_SFX_UP:
+		sfxVolume_ = std::min(1.0f, sfxVolume_ + 0.1f);
+		Engine::GetInstance().audio->SetSFXVolume(sfxVolume_);
+		break;
+
+	case BTN_SFX_DOWN:
+		sfxVolume_ = std::max(0.0f, sfxVolume_ - 0.1f);
+		Engine::GetInstance().audio->SetSFXVolume(sfxVolume_);
+		break;
+
+	case BTN_SETTINGS_BACK:
+		showSettings_ = false;
+		SetSettingsPanelVisible(false);
+		break;
+
 	default:
 		break;
 	}
 }
 
-// *********************************************
-// INTRO CINEMATIC
-// *********************************************
+void Scene::SetSettingsPanelVisible(bool visible)
+{
+	// Disable/enable settings-panel buttons and main buttons
+	auto& list = Engine::GetInstance().uiManager->UIElementsList;
 
-void Scene::LoadIntroCinematic() {
+	for (auto& el : list)
+	{
+		bool isSettingsBtn = (el->id >= BTN_SETTINGS_BACK && el->id <= BTN_SFX_DOWN)
+			|| el->id == BTN_SETTINGS_BACK;
+		bool isMainBtn = (el->id == BTN_PLAY || el->id == BTN_SETTINGS || el->id == BTN_EXIT);
+
+		if (isSettingsBtn)
+			el->state = visible ? UIElementState::NORMAL : UIElementState::DISABLED;
+
+		if (isMainBtn)
+			el->state = visible ? UIElementState::DISABLED : UIElementState::NORMAL;
+	}
+}
+
+// ============================================================================
+//  INTRO CINEMATIC
+// ============================================================================
+
+void Scene::LoadIntroCinematic()
+{
 	LOG("Playing intro cinematic...");
 	Engine::GetInstance().cinematics->PlayVideo("assets/video/test.mp4");
 }
 
-void Scene::UnloadIntroCinematic() {
+void Scene::UnloadIntroCinematic()
+{
 	Engine::GetInstance().cinematics->StopVideo();
 }
 
-void Scene::UpdateIntroCinematic(float dt) {
-	// When the video finishes (or is skipped), transition to gameplay
-	if (!Engine::GetInstance().cinematics->IsPlaying()) {
+void Scene::UpdateIntroCinematic(float dt)
+{
+	if (!Engine::GetInstance().cinematics->IsPlaying())
 		ChangeScene(SceneID::GAMEPLAY);
-	}
 }
 
-// *********************************************
-// GAMEPLAY (blank template — add your game here)
-// *********************************************
+// ============================================================================
+//  GAMEPLAY
+// ============================================================================
 
-void Scene::LoadGameplay() {
+void Scene::LoadGameplay()
+{
+	isPaused_ = false;
+	showPauseOptions_ = false;
 
-	// Load the map
 	Engine::GetInstance().map->Load("assets/maps/", "MapTemplate.tmx");
-
-	// Load entities from map (Player spawn point, etc.)
 	Engine::GetInstance().map->LoadEntities(player);
 
-	// If the map didn't contain an Entities object group, create the player manually
 	if (player == nullptr) {
-		player = std::dynamic_pointer_cast<Player>(Engine::GetInstance().entityManager->CreateEntity(EntityType::PLAYER));
+		player = std::dynamic_pointer_cast<Player>(
+			Engine::GetInstance().entityManager->CreateEntity(EntityType::PLAYER));
 		player->position = Vector2D(96, 672);
 		player->Start();
 	}
 
-	// ---- Add your game entities here ----
-	// Example:
-	// auto item = std::dynamic_pointer_cast<Item>(Engine::GetInstance().entityManager->CreateEntity(EntityType::ITEM));
-	// item->position = Vector2D(200, 672);
-	// item->Start();
+	// Create pause menu buttons (disabled until paused)
+	LoadPauseMenuButtons();
 }
 
-void Scene::UpdateGameplay(float dt) {
-	// ---- Add gameplay logic here ----
-}
-
-void Scene::UnloadGameplay() {
-
-	auto& uiManager = Engine::GetInstance().uiManager;
-	uiManager->CleanUp();
-
-	player.reset();
-
-	Engine::GetInstance().map->CleanUp();
-	Engine::GetInstance().entityManager->CleanUp();
-}
-
-void Scene::PostUpdateGameplay() {
-
-	// Save/Load game state
-	if (Engine::GetInstance().input->GetKey(SDL_SCANCODE_F5) == KEY_DOWN) {
-		Engine::GetInstance().saveSystem->QuickLoad();
+void Scene::UpdateGameplay(float dt)
+{
+	// Toggle pause with ESC
+	if (Engine::GetInstance().input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
+	{
+		if (showPauseOptions_) {
+			showPauseOptions_ = false;
+			SetPauseOptionsPanelVisible(false);
+		}
+		else {
+			isPaused_ = !isPaused_;
+			SetPauseMenuVisible(isPaused_);
+		}
 	}
 
-	if (Engine::GetInstance().input->GetKey(SDL_SCANCODE_F6) == KEY_DOWN) {
+	// Draw pause overlay BEFORE UIManager::Update so buttons render on top
+	if (isPaused_) DrawPauseMenu();
+}
+
+void Scene::UnloadGameplay()
+{
+	Engine::GetInstance().uiManager->CleanUp();
+	player.reset();
+	Engine::GetInstance().map->CleanUp();
+	Engine::GetInstance().entityManager->CleanUp();
+	isPaused_ = false;
+	showPauseOptions_ = false;
+}
+
+void Scene::PostUpdateGameplay()
+{
+	// Quick save/load shortcuts (only when not paused)
+	if (!isPaused_) {
+		if (Engine::GetInstance().input->GetKey(SDL_SCANCODE_F5) == KEY_DOWN)
+			Engine::GetInstance().saveSystem->QuickLoad();
+		if (Engine::GetInstance().input->GetKey(SDL_SCANCODE_F6) == KEY_DOWN)
+			Engine::GetInstance().saveSystem->QuickSave();
+	}
+}
+
+// ── Pause menu helpers ────────────────────────────────────────────────────────
+
+void Scene::LoadPauseMenuButtons()
+{
+	int winW = 0, winH = 0;
+	Engine::GetInstance().window->GetWindowSize(winW, winH);
+
+	const int btnW = 240;
+	const int btnH = 42;
+	const int btnX = winW / 2 - btnW / 2;
+	const int startY = winH / 2 - 115;
+	const int gap = 54;
+
+	// Main pause buttons
+	SDL_Rect contPos = { btnX, startY,          btnW, btnH };
+	SDL_Rect optPos = { btnX, startY + gap,     btnW, btnH };
+	SDL_Rect savePos = { btnX, startY + gap * 2, btnW, btnH };
+	SDL_Rect menuPos = { btnX, startY + gap * 3, btnW, btnH };
+	SDL_Rect quitPos = { btnX, startY + gap * 4, btnW, btnH };
+
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_CONTINUE, "CONTINUE", contPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPTIONS, "OPTIONS", optPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_SAVE, "SAVE GAME", savePos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_MAINMENU, "MAIN MENU", menuPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_QUIT, "QUIT GAME", quitPos, this);
+
+	// Options sub-panel buttons
+	const int panelW = 340;
+	const int panelX = winW / 2 - panelW / 2;
+	const int panelY = winH / 2 - 100;
+	const int smallBtnW = 40;
+	const int smallBtnH = 34;
+	const int rowH = 52;
+
+	SDL_Rect mUpPos = { panelX + panelW - smallBtnW - 12, panelY + 60,         smallBtnW, smallBtnH };
+	SDL_Rect mDownPos = { panelX + 12,                       panelY + 60,         smallBtnW, smallBtnH };
+	SDL_Rect sUpPos = { panelX + panelW - smallBtnW - 12, panelY + 60 + rowH,  smallBtnW, smallBtnH };
+	SDL_Rect sDownPos = { panelX + 12,                       panelY + 60 + rowH,  smallBtnW, smallBtnH };
+	SDL_Rect backPos = { panelX + panelW / 2 - 60,          panelY + 60 + rowH * 2 + 10, 120, btnH };
+
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPT_MUSIC_UP, "+", mUpPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPT_MUSIC_DOWN, "-", mDownPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPT_SFX_UP, "+", sUpPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPT_SFX_DOWN, "-", sDownPos, this);
+	Engine::GetInstance().uiManager->CreateUIElement(UIElementType::BUTTON, BTN_PAUSE_OPT_BACK, "BACK", backPos, this);
+
+	// Everything disabled until paused
+	SetPauseMenuVisible(false);
+}
+
+void Scene::SetPauseMenuVisible(bool visible)
+{
+	auto& list = Engine::GetInstance().uiManager->UIElementsList;
+	for (auto& el : list)
+	{
+		bool isPauseMain = (el->id >= BTN_PAUSE_CONTINUE && el->id <= BTN_PAUSE_QUIT);
+		if (isPauseMain)
+			el->state = visible ? UIElementState::NORMAL : UIElementState::DISABLED;
+
+		// Always hide options sub-panel when toggling main
+		bool isOpt = (el->id >= BTN_PAUSE_OPT_MUSIC_UP && el->id <= BTN_PAUSE_OPT_BACK);
+		if (isOpt)
+			el->state = UIElementState::DISABLED;
+	}
+}
+
+void Scene::SetPauseOptionsPanelVisible(bool visible)
+{
+	auto& list = Engine::GetInstance().uiManager->UIElementsList;
+	for (auto& el : list)
+	{
+		bool isPauseMain = (el->id >= BTN_PAUSE_CONTINUE && el->id <= BTN_PAUSE_QUIT);
+		bool isOpt = (el->id >= BTN_PAUSE_OPT_MUSIC_UP && el->id <= BTN_PAUSE_OPT_BACK);
+
+		if (isPauseMain)
+			el->state = visible ? UIElementState::DISABLED : UIElementState::NORMAL;
+		if (isOpt)
+			el->state = visible ? UIElementState::NORMAL : UIElementState::DISABLED;
+	}
+}
+
+void Scene::DrawPauseMenu()
+{
+	auto& render = *Engine::GetInstance().render;
+	int winW = 0, winH = 0;
+	Engine::GetInstance().window->GetWindowSize(winW, winH);
+
+	// ── Dark overlay ─────────────────────────────────────────────────────────
+	SDL_Rect overlay = { 0, 0, winW, winH };
+	render.DrawRectangle(overlay, 0, 0, 0, 180, true, false);
+
+	if (showPauseOptions_)
+	{
+		DrawPauseOptionsPanel(winW, winH);
+		return;
+	}
+
+	// ── Panel background ─────────────────────────────────────────────────────
+	const int panelW = 300;
+	const int panelH = 340;
+	const int panelX = winW / 2 - panelW / 2;
+	const int panelY = winH / 2 - 180;
+
+	SDL_Rect panelBg = { panelX, panelY, panelW, panelH };
+	SDL_Rect panelSh = { panelX + 4, panelY + 4, panelW, panelH };
+	render.DrawRectangle(panelSh, 0, 0, 0, 100, true, false);
+	render.DrawRectangle(panelBg, 8, 12, 22, 250, true, false);
+	render.DrawRectangle(panelBg, 60, 90, 150, 200, false, false);
+
+	// Top accent bar
+	SDL_Rect topBar = { panelX, panelY, panelW, 4 };
+	render.DrawRectangle(topBar, 80, 140, 200, 255, true, false);
+
+	// ── PAUSED title ─────────────────────────────────────────────────────────
+	render.DrawText("PAUSED", panelX + panelW / 2 - 37, panelY + 14, 0, 0,
+		{ 180, 210, 240, 255 });
+
+	// Thin separator
+	render.DrawLine(panelX + 20, panelY + 46, panelX + panelW - 20, panelY + 46,
+		60, 100, 160, 150, false);
+}
+
+void Scene::DrawPauseOptionsPanel(int winW, int winH)
+{
+	auto& render = *Engine::GetInstance().render;
+
+	const int panelW = 340;
+	const int panelH = 240;
+	const int panelX = winW / 2 - panelW / 2;
+	const int panelY = winH / 2 - 100;
+	const int rowH = 52;
+
+	SDL_Rect panel = { panelX, panelY, panelW, panelH };
+	render.DrawRectangle(panel, 8, 12, 22, 250, true, false);
+	render.DrawRectangle(panel, 60, 90, 150, 200, false, false);
+
+	SDL_Rect topBar = { panelX, panelY, panelW, 4 };
+	render.DrawRectangle(topBar, 80, 140, 200, 255, true, false);
+
+	render.DrawText("OPTIONS", panelX + panelW / 2 - 42, panelY + 14, 0, 0,
+		{ 180, 210, 240, 255 });
+
+	// Music row
+	render.DrawText("MUSIC", panelX + 60, panelY + 66, 0, 0, { 150, 180, 210, 220 });
+	SDL_Rect mBarBg = { panelX + 60, panelY + 86, panelW - 120, 8 };
+	render.DrawRectangle(mBarBg, 30, 40, 60, 200, true, false);
+	int mFill = (int)((panelW - 120) * musicVolume_);
+	SDL_Rect mBarFill = { panelX + 60, panelY + 86, mFill, 8 };
+	render.DrawRectangle(mBarFill, 80, 160, 220, 255, true, false);
+	char vol[8];
+	snprintf(vol, sizeof(vol), "%d%%", (int)(musicVolume_ * 100));
+	render.DrawText(vol, panelX + panelW / 2 - 15, panelY + 60, 0, 0, { 200, 220, 240, 255 });
+
+	// SFX row
+	render.DrawText("SFX", panelX + 60, panelY + 66 + rowH, 0, 0, { 150, 180, 210, 220 });
+	SDL_Rect sBarBg = { panelX + 60, panelY + 86 + rowH, panelW - 120, 8 };
+	render.DrawRectangle(sBarBg, 30, 40, 60, 200, true, false);
+	int sFill = (int)((panelW - 120) * sfxVolume_);
+	SDL_Rect sBarFill = { panelX + 60, panelY + 86 + rowH, sFill, 8 };
+	render.DrawRectangle(sBarFill, 80, 160, 220, 255, true, false);
+	snprintf(vol, sizeof(vol), "%d%%", (int)(sfxVolume_ * 100));
+	render.DrawText(vol, panelX + panelW / 2 - 15, panelY + 60 + rowH, 0, 0, { 200, 220, 240, 255 });
+}
+
+void Scene::HandlePauseMenuUIEvents(UIElement* uiElement)
+{
+	switch (uiElement->id)
+	{
+	case BTN_PAUSE_CONTINUE:
+		isPaused_ = false;
+		SetPauseMenuVisible(false);
+		break;
+
+	case BTN_PAUSE_OPTIONS:
+		showPauseOptions_ = true;
+		SetPauseOptionsPanelVisible(true);
+		break;
+
+	case BTN_PAUSE_SAVE:
 		Engine::GetInstance().saveSystem->QuickSave();
+		// Brief visual feedback: show saved message (next frame)
+		LOG("Game saved from pause menu");
+		break;
+
+	case BTN_PAUSE_MAINMENU:
+		isPaused_ = false;
+		hasPendingSceneChange = true;
+		pendingScene = SceneID::MAIN_MENU;
+		break;
+
+	case BTN_PAUSE_QUIT:
+	{
+		SDL_Event quitEvent;
+		quitEvent.type = SDL_EVENT_QUIT;
+		SDL_PushEvent(&quitEvent);
+		break;
+	}
+
+	// ── Options sub-panel ────────────────────────────────────────────────────
+	case BTN_PAUSE_OPT_MUSIC_UP:
+		musicVolume_ = std::min(1.0f, musicVolume_ + 0.1f);
+		Engine::GetInstance().audio->SetMusicVolume(musicVolume_);
+		break;
+	case BTN_PAUSE_OPT_MUSIC_DOWN:
+		musicVolume_ = std::max(0.0f, musicVolume_ - 0.1f);
+		Engine::GetInstance().audio->SetMusicVolume(musicVolume_);
+		break;
+	case BTN_PAUSE_OPT_SFX_UP:
+		sfxVolume_ = std::min(1.0f, sfxVolume_ + 0.1f);
+		Engine::GetInstance().audio->SetSFXVolume(sfxVolume_);
+		break;
+	case BTN_PAUSE_OPT_SFX_DOWN:
+		sfxVolume_ = std::max(0.0f, sfxVolume_ - 0.1f);
+		Engine::GetInstance().audio->SetSFXVolume(sfxVolume_);
+		break;
+	case BTN_PAUSE_OPT_BACK:
+		showPauseOptions_ = false;
+		SetPauseOptionsPanelVisible(false);
+		break;
+
+	default: break;
 	}
 }

--- a/src/UIButton.cpp
+++ b/src/UIButton.cpp
@@ -3,63 +3,86 @@
 #include "Engine.h"
 #include "Audio.h"
 
+static constexpr int FONT_H = 25;
+
 UIButton::UIButton(int id, SDL_Rect bounds, const char* text) : UIElement(UIElementType::BUTTON, id)
 {
 	this->bounds = bounds;
 	this->text = text;
-
 	canClick = true;
 	drawBasic = false;
 }
 
-UIButton::~UIButton()
-{
-
-}
+UIButton::~UIButton() {}
 
 bool UIButton::Update(float dt)
 {
-	if (state != UIElementState::DISABLED)
+	if (state == UIElementState::DISABLED) return false;
+
+	Vector2D mousePos = Engine::GetInstance().input->GetMousePosition();
+
+	bool hovered = (mousePos.getX() > bounds.x &&
+		mousePos.getX() < bounds.x + bounds.w &&
+		mousePos.getY() > bounds.y &&
+		mousePos.getY() < bounds.y + bounds.h);
+
+	if (hovered)
 	{
-		// L16: TODO 3: Update the state of the GUiButton according to the mouse position
-		Vector2D mousePos = Engine::GetInstance().input->GetMousePosition();
+		state = UIElementState::FOCUSED;
+		if (Engine::GetInstance().input->GetMouseButtonDown(SDL_BUTTON_LEFT) == KEY_REPEAT)
+			state = UIElementState::PRESSED;
+		if (Engine::GetInstance().input->GetMouseButtonDown(SDL_BUTTON_LEFT) == KEY_UP)
+			NotifyObserver();
+	}
+	else
+	{
+		state = UIElementState::NORMAL;
+	}
 
-		//If the position of the mouse if inside the bounds of the button 
-		if (mousePos.getX() > bounds.x && mousePos.getX() < bounds.x + bounds.w && mousePos.getY() > bounds.y && mousePos.getY() < bounds.y + bounds.h) {
+	// Vertical centre: font is 25px tall
+	int textY = bounds.y + (bounds.h - FONT_H) / 2;
+	int textX = bounds.x + 16;
 
-			state = UIElementState::FOCUSED;
+	SDL_Rect shadow = { bounds.x + 3, bounds.y + 3, bounds.w, bounds.h };
 
-			if (Engine::GetInstance().input->GetMouseButtonDown(SDL_BUTTON_LEFT) == KEY_REPEAT) {
-				state = UIElementState::PRESSED;
-			}
-
-			if (Engine::GetInstance().input->GetMouseButtonDown(SDL_BUTTON_LEFT) == KEY_UP) {
-				NotifyObserver();
-			}
-		}
-		else {
-			state = UIElementState::NORMAL;
-		}
-
-		//L16: TODO 4: Draw the button according the GuiControl State
-		switch (state)
+	switch (state)
+	{
+	case UIElementState::NORMAL:
+		Engine::GetInstance().render->DrawRectangle(shadow, 0, 0, 0, 80, true, false);
+		Engine::GetInstance().render->DrawRectangle(bounds, 15, 15, 25, 220, true, false);
 		{
-		case UIElementState::DISABLED:
-			Engine::GetInstance().render->DrawRectangle(bounds, 200, 200, 200, 255, true, false);
-			break;
-		case UIElementState::NORMAL:
-			Engine::GetInstance().render->DrawRectangle(bounds, 0, 0, 255, 255, true, false);
-			break;
-		case UIElementState::FOCUSED:
-			Engine::GetInstance().render->DrawRectangle(bounds, 0, 0, 20, 255, true, false);
-			break;
-		case UIElementState::PRESSED:
-			Engine::GetInstance().render->DrawRectangle(bounds, 0, 255, 0, 255, true, false);
-			break;
+			SDL_Rect accent = { bounds.x, bounds.y, 3, bounds.h };
+			Engine::GetInstance().render->DrawRectangle(accent, 80, 140, 200, 255, true, false);
 		}
+		Engine::GetInstance().render->DrawRectangle(bounds, 60, 80, 120, 180, false, false);
+		Engine::GetInstance().render->DrawText(text.c_str(), textX, textY, 0, 0, { 180, 200, 220, 255 });
+		break;
 
-		Engine::GetInstance().render->DrawText(text.c_str(), bounds.x, bounds.y, bounds.w, bounds.h, {255,255,255,255});
+	case UIElementState::FOCUSED:
+		Engine::GetInstance().render->DrawRectangle(shadow, 0, 0, 0, 60, true, false);
+		Engine::GetInstance().render->DrawRectangle(bounds, 25, 35, 60, 240, true, false);
+		{
+			SDL_Rect accent = { bounds.x, bounds.y, 4, bounds.h };
+			Engine::GetInstance().render->DrawRectangle(accent, 100, 180, 255, 255, true, false);
+		}
+		Engine::GetInstance().render->DrawRectangle(bounds, 80, 120, 180, 220, false, false);
+		Engine::GetInstance().render->DrawText(text.c_str(), textX, textY, 0, 0, { 220, 235, 255, 255 });
+		break;
 
+	case UIElementState::PRESSED:
+		Engine::GetInstance().render->DrawRectangle(bounds, 10, 60, 120, 255, true, false);
+		{
+			SDL_Rect accent = { bounds.x, bounds.y, 4, bounds.h };
+			Engine::GetInstance().render->DrawRectangle(accent, 140, 220, 255, 255, true, false);
+		}
+		Engine::GetInstance().render->DrawRectangle(bounds, 100, 160, 220, 255, false, false);
+		Engine::GetInstance().render->DrawText(text.c_str(), textX + 2, textY + 1, 0, 0, { 255, 255, 255, 255 });
+		break;
+
+	default:
+		Engine::GetInstance().render->DrawRectangle(bounds, 40, 40, 40, 160, true, false);
+		Engine::GetInstance().render->DrawText(text.c_str(), textX, textY, 0, 0, { 100, 100, 100, 200 });
+		break;
 	}
 
 	return false;


### PR DESCRIPTION
- Add styled main menu with PLAY, SETTINGS and EXIT buttons
- Add settings panel (music/SFX volume controls) in main menu
- Add pause menu triggered by ESC during gameplay with:
  - CONTINUE, OPTIONS, SAVE GAME, MAIN MENU, QUIT GAME buttons
  - Options sub-panel with volume controls
- Fix DrawText in Render.cpp to apply window scale correctly
- Fix rendering order: background drawn before UIManager buttons
- Fix settings panel flicker using frame cooldown

Modified files:
  src/Scene.cpp src/Scene.h src/UIButton.cpp src/Render.cpp

## Canvis
<!-- Descripció breu dels canvis -->

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [x] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [x] El codi compila sense errors
- [x] He provat els canvis localment
- [x] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [x] He usat Conventional Commits al títol del PR
- [x] He enllaçat la Issue corresponent
