### PR TITLE
feat: FSM del enemic B (Bloc, melee sense embestida) #16

### DIFF
--- a/assets/maps/MapTemplate.tmx
+++ b/assets/maps/MapTemplate.tmx
@@ -20584,5 +20584,11 @@
  <objectgroup id="9" name="Entities">
   <object id="11" name="Player" type="Player" x="6841" y="4702.67" width="96" height="96"/>
   <object id="12" name="Enemy" type="Enemy" x="4750" y="4661" width="32" height="32"/>
+  <object id="13" name="EnemyB" type="EnemyB" x="6200" y="4661" width="32" height="32">
+   <properties>
+    <property name="patrol_left" type="float" value="6000"/>
+    <property name="patrol_right" type="float" value="6400"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/assets/textures/animations/blocTurnaroundAnimation.xml
+++ b/assets/textures/animations/blocTurnaroundAnimation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="1.11.2" name="blocTurnaroundAnimation" tilewidth="128" tileheight="128" tilecount="4" columns="4">
+ <image source="../spritesheets/SS enemics C/spritesheet_bloc_turnaround.png" width="512" height="128"/>
+ <tile id="0" type="turn">
+  <animation>
+   <frame tileid="0" duration="100"/>
+   <frame tileid="1" duration="100"/>
+   <frame tileid="2" duration="100"/>
+   <frame tileid="3" duration="100"/>
+  </animation>
+ </tile>
+</tileset>

--- a/assets/textures/animations/blocWalkingAnimation.xml
+++ b/assets/textures/animations/blocWalkingAnimation.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="1.11.2" name="blocWalkingAnimation" tilewidth="128" tileheight="128" tilecount="14" columns="14">
+ <image source="../spritesheets/SS enemics C/spritesheet_bloc_walking.png" width="1792" height="128"/>
+ <tile id="0" type="walk">
+  <animation>
+   <frame tileid="0" duration="80"/>
+   <frame tileid="1" duration="80"/>
+   <frame tileid="2" duration="80"/>
+   <frame tileid="3" duration="80"/>
+   <frame tileid="4" duration="80"/>
+   <frame tileid="5" duration="80"/>
+   <frame tileid="6" duration="80"/>
+   <frame tileid="7" duration="80"/>
+   <frame tileid="8" duration="80"/>
+   <frame tileid="9" duration="80"/>
+   <frame tileid="10" duration="80"/>
+   <frame tileid="11" duration="80"/>
+   <frame tileid="12" duration="80"/>
+   <frame tileid="13" duration="80"/>
+  </animation>
+ </tile>
+</tileset>

--- a/include/EnemyB.h
+++ b/include/EnemyB.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "Entity.h"
+#include "Animation.h"
+#include <box2d/box2d.h>
+#include <SDL3/SDL.h>
+#include <cmath>
+
+struct SDL_Texture;
+
+enum class EnemyBState { IDLE, PATROL, TURNING, CHASE, ATTACK, STUNNED, DEATH };
+
+class EnemyB : public Entity
+{
+public:
+	EnemyB();
+	virtual ~EnemyB();
+	bool Awake();
+	bool Start();
+	bool Update(float dt);
+	bool CleanUp();
+	void OnCollision(PhysBody* physA, PhysBody* physB);
+	void OnCollisionEnd(PhysBody* physA, PhysBody* physB);
+	void SetPosition(Vector2D pos);
+	Vector2D GetPosition();
+	bool Destroy();
+	void TakeDamage(int damage) override;
+	void SetPatrolPoints(float leftX, float rightX);
+
+public:
+	float speed = 2.0f;
+	SDL_Texture* walkTexture = nullptr;
+	SDL_Texture* turnTexture = nullptr;
+	int texW = 128;
+	int texH = 128;
+	PhysBody* pbody = nullptr;
+
+private:
+	void UpdateFSM(float dt);
+	void TransitionTo(EnemyBState newState);
+	void GetPhysicsValues();
+	void ApplyPhysics();
+	void Draw(float dt);
+
+	b2Vec2 velocity    = { 0.0f, 0.0f };
+	bool   facingRight_ = false;
+
+	AnimationSet walkAnims_;
+	AnimationSet turnAnims_;
+
+	EnemyBState state_      = EnemyBState::IDLE;
+	float       stateTimer_ = 0.0f;
+
+	// Tunable constants
+	static constexpr float DETECTION_RADIUS      = 250.0f;
+	static constexpr float ATTACK_RANGE          = 75.0f;
+	static constexpr float ATTACK_RANGE_Y        = 60.0f;
+	static constexpr float IDLE_DURATION         = 1000.0f;
+	static constexpr float ATTACK_DURATION       = 400.0f;
+	static constexpr float STUN_DURATION         = 1800.0f;
+
+	// Patrol
+	float patrolLeftX_  = 0.0f;
+	float patrolRightX_ = 0.0f;
+	float patrolDirX_   = 1.0f;
+
+	// Contact damage
+	static constexpr float CONTACT_DAMAGE_INTERVAL = 1000.0f;
+	bool    isContactWithPlayer_   = false;
+	float   contactDamageCooldown_ = 0.0f;
+	Entity* playerListener_        = nullptr;
+};

--- a/include/Entity.h
+++ b/include/Entity.h
@@ -8,6 +8,7 @@ enum class EntityType
 	PLAYER,
 	ITEM,
 	ENEMY,
+	ENEMY_B,
 	CHECKPOINT,
 	BOX,
 	UNKNOWN

--- a/include/Player.h
+++ b/include/Player.h
@@ -33,8 +33,9 @@ public:
 
 	void TakeDamage(int damage) override;
 	void Revive();
+	bool IsDead() const { return isDead_; }
 
-	// Map viewer helpers 
+	// Map viewer helpers
 	SDL_Rect GetCurrentAnimationRect() const;
 	bool     IsFacingRight() const;
 

--- a/src/EnemyB.cpp
+++ b/src/EnemyB.cpp
@@ -1,0 +1,368 @@
+#include "EnemyB.h"
+#include "Engine.h"
+#include "Textures.h"
+#include "Render.h"
+#include "Scene.h"
+#include "Log.h"
+#include "Physics.h"
+#include "Window.h"
+#include "tracy/Tracy.hpp"
+
+EnemyB::EnemyB() : Entity(EntityType::ENEMY_B)
+{
+	name = "EnemyB";
+}
+
+EnemyB::~EnemyB() {}
+
+bool EnemyB::Awake() { return true; }
+
+bool EnemyB::Start()
+{
+	std::unordered_map<int, std::string> walkAliases = { {0, "walk"} };
+	walkAnims_.LoadFromTSX("assets/textures/animations/blocWalkingAnimation.xml", walkAliases);
+	walkAnims_.SetCurrent("walk");
+	walkTexture = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS enemics C/spritesheet_bloc_walking.png");
+
+	std::unordered_map<int, std::string> turnAliases = { {0, "turn"} };
+	turnAnims_.LoadFromTSX("assets/textures/animations/blocTurnaroundAnimation.xml", turnAliases);
+	turnAnims_.SetCurrent("turn");
+	turnAnims_.SetLoop("turn", false);
+	turnTexture = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS enemics C/spritesheet_bloc_turnaround.png");
+
+	pbody = Engine::GetInstance().physics->CreateCapsule(
+		(int)position.getX() + texW / 2,
+		(int)position.getY() + texH / 2,
+		20, 50, bodyType::DYNAMIC);
+
+	pbody->listener = this;
+	pbody->ctype    = ColliderType::ENEMY;
+
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+	if (patrolLeftX_ == 0.0f && patrolRightX_ == 0.0f)
+	{
+		patrolLeftX_  = (float)bodyX - 200.0f;
+		patrolRightX_ = (float)bodyX + 200.0f;
+	}
+
+	TransitionTo(EnemyBState::IDLE);
+	return true;
+}
+
+bool EnemyB::Update(float dt)
+{
+	ZoneScoped;
+
+	if (Engine::GetInstance().scene->isPaused_) {
+		Draw(0.0f);
+		return true;
+	}
+
+	GetPhysicsValues();
+	UpdateFSM(dt);
+	ApplyPhysics();
+
+	if (contactDamageCooldown_ > 0.0f) contactDamageCooldown_ -= dt;
+	if (isContactWithPlayer_ && playerListener_ != nullptr && contactDamageCooldown_ <= 0.0f)
+	{
+		playerListener_->TakeDamage(1);
+		contactDamageCooldown_ = CONTACT_DAMAGE_INTERVAL;
+	}
+
+	Draw(dt);
+	return true;
+}
+
+void EnemyB::UpdateFSM(float dt)
+{
+	if (state_ == EnemyBState::DEATH) return;
+
+	auto& player = Engine::GetInstance().scene->player;
+	if (player != nullptr && player->IsDead())
+	{
+		velocity.x = 0.0f;
+		return;
+	}
+
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+
+	int playerBodyX, playerBodyY;
+	Engine::GetInstance().scene->player->pbody->GetPosition(playerBodyX, playerBodyY);
+	float dx           = (float)playerBodyX - (float)bodyX;
+	float dy           = (float)playerBodyY - (float)bodyY;
+	float distToPlayer = std::abs(dx);
+
+	switch (state_)
+	{
+	case EnemyBState::IDLE:
+		velocity.x = 0.0f;
+		stateTimer_ -= dt;
+		if (stateTimer_ <= 0.0f)
+			TransitionTo(EnemyBState::PATROL);
+		if (distToPlayer < DETECTION_RADIUS)
+			TransitionTo(EnemyBState::CHASE);
+		break;
+
+	case EnemyBState::PATROL:
+		if (distToPlayer < DETECTION_RADIUS)
+		{
+			TransitionTo(EnemyBState::CHASE);
+			break;
+		}
+		if (patrolDirX_ > 0.0f && (float)bodyX >= patrolRightX_)
+		{
+			TransitionTo(EnemyBState::TURNING);
+			break;
+		}
+		if (patrolDirX_ < 0.0f && (float)bodyX <= patrolLeftX_)
+		{
+			TransitionTo(EnemyBState::TURNING);
+			break;
+		}
+		velocity.x   = patrolDirX_ * speed;
+		facingRight_ = (patrolDirX_ < 0.0f);
+		break;
+
+	case EnemyBState::TURNING:
+		velocity.x = 0.0f;
+		if (turnAnims_.HasFinishedOnce("turn"))
+		{
+			patrolDirX_  = -patrolDirX_;
+			facingRight_ = (patrolDirX_ < 0.0f);
+			TransitionTo(EnemyBState::PATROL);
+		}
+		break;
+
+	case EnemyBState::CHASE:
+		if (distToPlayer > DETECTION_RADIUS * 1.5f)
+		{
+			TransitionTo(EnemyBState::PATROL);
+			break;
+		}
+		if (distToPlayer < ATTACK_RANGE && std::abs(dy) < ATTACK_RANGE_Y)
+		{
+			TransitionTo(EnemyBState::ATTACK);
+			break;
+		}
+		velocity.x   = (dx > 0.0f) ? speed : -speed;
+		facingRight_ = (dx < 0.0f);
+		break;
+
+	case EnemyBState::ATTACK:
+		velocity.x = 0.0f;
+		stateTimer_ -= dt;
+		if (stateTimer_ <= 0.0f)
+			TransitionTo(EnemyBState::STUNNED);
+		break;
+
+	case EnemyBState::STUNNED:
+		velocity.x = 0.0f;
+		stateTimer_ -= dt;
+		if (stateTimer_ <= 0.0f)
+		{
+			if (distToPlayer < DETECTION_RADIUS)
+				TransitionTo(EnemyBState::CHASE);
+			else
+				TransitionTo(EnemyBState::PATROL);
+		}
+		break;
+	}
+}
+
+void EnemyB::TransitionTo(EnemyBState newState)
+{
+	state_ = newState;
+
+	switch (newState)
+	{
+	case EnemyBState::IDLE:
+		stateTimer_ = IDLE_DURATION;
+		break;
+
+	case EnemyBState::TURNING:
+		turnAnims_.SetCurrent("turn");
+		turnAnims_.ResetCurrent();
+		velocity.x = 0.0f;
+		break;
+
+	case EnemyBState::ATTACK:
+	{
+		stateTimer_ = ATTACK_DURATION;
+		int bodyX, bodyY;
+		pbody->GetPosition(bodyX, bodyY);
+		int playerBX, playerBY;
+		Engine::GetInstance().scene->player->pbody->GetPosition(playerBX, playerBY);
+		facingRight_ = ((float)playerBX < (float)bodyX);
+		auto& pl = Engine::GetInstance().scene->player;
+		if (pl && !pl->IsDead()) pl->TakeDamage(1);
+		LOG("EnemyB: ATTACK");
+		break;
+	}
+
+	case EnemyBState::STUNNED:
+		stateTimer_ = STUN_DURATION;
+		velocity.x  = 0.0f;
+		break;
+
+	case EnemyBState::DEATH:
+		LOG("EnemyB: DEATH");
+		Destroy();
+		break;
+
+	default:
+		break;
+	}
+}
+
+void EnemyB::GetPhysicsValues()
+{
+	velocity   = Engine::GetInstance().physics->GetLinearVelocity(pbody);
+	velocity.x = 0.0f;
+}
+
+void EnemyB::ApplyPhysics()
+{
+	Engine::GetInstance().physics->SetLinearVelocity(pbody, velocity);
+}
+
+void EnemyB::Draw(float dt)
+{
+	int x, y;
+	pbody->GetPosition(x, y);
+	position.setX((float)x);
+	position.setY((float)y);
+
+	if (Engine::GetInstance().physics->IsDebug())
+	{
+		auto& render = Engine::GetInstance().render;
+		int scale    = Engine::GetInstance().window->GetScale();
+		int cx = render->camera.x + x * scale;
+		int cy = render->camera.y + y * scale;
+
+		// Detection radius circle
+		constexpr int SEGMENTS = 32;
+		int r = (int)(DETECTION_RADIUS * scale);
+		SDL_SetRenderDrawColor(render->renderer, 255, 255, 0, 180);
+		for (int i = 0; i < SEGMENTS; i++)
+		{
+			float a0 = (float)i       / SEGMENTS * 6.2832f;
+			float a1 = (float)(i + 1) / SEGMENTS * 6.2832f;
+			SDL_RenderLine(render->renderer,
+				cx + (int)(SDL_cosf(a0) * r), cy + (int)(SDL_sinf(a0) * r),
+				cx + (int)(SDL_cosf(a1) * r), cy + (int)(SDL_sinf(a1) * r));
+		}
+
+		// Line to player only while chasing or attacking
+		if (state_ == EnemyBState::CHASE || state_ == EnemyBState::ATTACK)
+		{
+			Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+			int sx2 = render->camera.x + (int)playerPos.getX() * scale;
+			int sy2 = render->camera.y + (int)playerPos.getY() * scale;
+			SDL_SetRenderDrawColor(render->renderer, 255, 50, 50, 255);
+			SDL_RenderLine(render->renderer, cx, cy, sx2, sy2);
+		}
+	}
+
+	SDL_FlipMode flip = facingRight_ ? SDL_FLIP_NONE : SDL_FLIP_HORIZONTAL;
+
+	if (state_ == EnemyBState::TURNING)
+	{
+		turnAnims_.Update(dt);
+		const SDL_Rect& frame = turnAnims_.GetCurrentFrame();
+		Engine::GetInstance().render->DrawTexture(turnTexture, x - texW / 2, y - texH / 2, &frame, 1.0f, 0, INT_MAX, INT_MAX, flip, 1.0f);
+	}
+	else
+	{
+		walkAnims_.Update(dt);
+		const SDL_Rect& frame = walkAnims_.GetCurrentFrame();
+		Engine::GetInstance().render->DrawTexture(walkTexture, x - texW / 2, y - texH / 2, &frame, 1.0f, 0, INT_MAX, INT_MAX, flip, 1.0f);
+	}
+}
+
+bool EnemyB::CleanUp()
+{
+	LOG("Cleanup EnemyB");
+	Engine::GetInstance().textures->UnLoad(walkTexture);
+	Engine::GetInstance().textures->UnLoad(turnTexture);
+	Engine::GetInstance().physics->DeletePhysBody(pbody);
+	return true;
+}
+
+bool EnemyB::Destroy()
+{
+	LOG("Destroying EnemyB");
+	active = false;
+	pendingToDelete = true;
+	return true;
+}
+
+void EnemyB::SetPosition(Vector2D pos)
+{
+	pbody->SetPosition((int)pos.getX(), (int)pos.getY());
+}
+
+Vector2D EnemyB::GetPosition()
+{
+	int x, y;
+	pbody->GetPosition(x, y);
+	return Vector2D((float)x - texW / 2, (float)y - texH / 2);
+}
+
+void EnemyB::SetPatrolPoints(float leftX, float rightX)
+{
+	patrolLeftX_  = leftX;
+	patrolRightX_ = rightX;
+}
+
+void EnemyB::OnCollision(PhysBody* physA, PhysBody* physB)
+{
+	if (physB->ctype == ColliderType::ATTACK)
+	{
+		TakeDamage(1);
+	}
+	else if (physB->ctype == ColliderType::PLAYER)
+	{
+		isContactWithPlayer_ = true;
+		playerListener_      = physB->listener;
+		if (contactDamageCooldown_ <= 0.0f)
+		{
+			playerListener_->TakeDamage(1);
+			contactDamageCooldown_ = CONTACT_DAMAGE_INTERVAL;
+		}
+	}
+}
+
+void EnemyB::OnCollisionEnd(PhysBody* physA, PhysBody* physB)
+{
+	if (physB->ctype == ColliderType::PLAYER)
+	{
+		isContactWithPlayer_ = false;
+		playerListener_      = nullptr;
+	}
+}
+
+void EnemyB::TakeDamage(int damage)
+{
+	if (state_ == EnemyBState::DEATH) return;
+
+	health -= damage;
+	LOG("EnemyB recibio %d de dano -> vida: %d/%d", damage, health, maxHealth);
+
+	Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+	float dirX = ((float)bodyX > playerPos.getX()) ? 1.0f : -1.0f;
+	Engine::GetInstance().physics->ApplyLinearImpulseToCenter(pbody, dirX * 5.0f, -3.0f, true);
+
+	if (health <= 0)
+	{
+		health = 0;
+		TransitionTo(EnemyBState::DEATH);
+	}
+	else
+	{
+		TransitionTo(EnemyBState::STUNNED);
+	}
+}

--- a/src/EntityManager.cpp
+++ b/src/EntityManager.cpp
@@ -6,6 +6,7 @@
 #include "Log.h"
 #include "Item.h"
 #include "Enemy.h"
+#include "EnemyB.h"
 #include "Checkpoint.h"
 #include "Box.h"
 #include "tracy/Tracy.hpp"
@@ -78,6 +79,9 @@ std::shared_ptr<Entity> EntityManager::CreateEntity(EntityType type)
 		break;
 	case EntityType::ENEMY:
 		entity = std::make_shared<Enemy>();
+		break;
+	case EntityType::ENEMY_B:
+		entity = std::make_shared<EnemyB>();
 		break;
 	case EntityType::CHECKPOINT:
 		entity = std::make_shared<Checkpoint>();

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -6,6 +6,7 @@
 #include "Physics.h"
 #include "EntityManager.h"
 #include "Enemy.h"
+#include "EnemyB.h"
 #include "Checkpoint.h"
 #include "Box.h"
 #include "Window.h"
@@ -522,6 +523,23 @@ void Map::LoadEntities(std::shared_ptr<Player>& player) {
                     enemy->position = Vector2D(x, y);
                     enemy->Start();
                     LOG("Enemy spawned at: %f, %f", x, y);
+                }
+                else if (entityType == "EnemyB") {
+                    auto enemy = std::dynamic_pointer_cast<EnemyB>(Engine::GetInstance().entityManager->CreateEntity(EntityType::ENEMY_B));
+                    enemy->position = Vector2D(x, y);
+                    float patrolLeft  = x - 200.0f;
+                    float patrolRight = x + 200.0f;
+                    pugi::xml_node props = objectNode.child("properties");
+                    if (props) {
+                        for (pugi::xml_node prop = props.child("property"); prop; prop = prop.next_sibling("property")) {
+                            std::string propName = prop.attribute("name").as_string();
+                            if (propName == "patrol_left")  patrolLeft  = prop.attribute("value").as_float();
+                            if (propName == "patrol_right") patrolRight = prop.attribute("value").as_float();
+                        }
+                    }
+                    enemy->SetPatrolPoints(patrolLeft, patrolRight);
+                    enemy->Start();
+                    LOG("EnemyB spawned at: %f, %f (patrol: %.0f-%.0f)", x, y, patrolLeft, patrolRight);
                 }
                 else if (entityType == "Checkpoint") {
                     auto checkpoint = std::dynamic_pointer_cast<Checkpoint>(Engine::GetInstance().entityManager->CreateEntity(EntityType::CHECKPOINT));


### PR DESCRIPTION
## Canvis #16 
- Nous estats IDLE/PATROL/TURNING/CHASE/ATTACK/STUNNED/DEATH
- Animacions walking i turnaround (sprites Bloc, 128x128)
- Atac directe quan el jugador esta a prop (sense embestida)
- Gir suau en els extrems de patrulla amb animacio turnaround
- Punts de patrulla configurables des del TMX (patrol_left/patrol_right)
- Rang d atac bidimensional (horitzontal + vertical) per evitar atacar quan el jugador salta per sobre
- Depuracio F9: cercle de deteccio i linia cap al jugador en CHASE/ATTACK
- L enemic s atura quan el jugador mor
- Nou EntityType::ENEMY_B i spawner al Map
- IsDead() afegit al Player

## Tipus de canvi
- [x] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [x] El codi compila sense errors
- [x] He provat els canvis localment
- [x] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [x] He usat Conventional Commits al títol del PR
- [x] He enllaçat la Issue corresponent
