### PR TITLE
Add EnemyC ranged enemy and Projectile entity

### DIFF
--- a/assets/maps/MapTemplate.tmx
+++ b/assets/maps/MapTemplate.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="130" height="77" tilewidth="64" tileheight="64" infinite="0" nextlayerid="32" nextobjectid="283">
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="130" height="77" tilewidth="64" tileheight="64" infinite="0" nextlayerid="32" nextobjectid="284">
  <tileset firstgid="1" name="MapMetadata" tilewidth="32" tileheight="32" spacing="1" margin="1" tilecount="2" columns="2">
   <image source="MapMetadata.png" width="67" height="34"/>
  </tileset>
@@ -20583,6 +20583,7 @@
  </layer>
  <objectgroup id="9" name="Entities">
   <object id="11" name="Player" type="Player" x="6841" y="4702.67" width="96" height="96"/>
-  <object id="12" name="Enemy" type="Enemy" x="4750" y="4661" width="32" height="32"/>
+  <object id="12" name="EnemyC" type="EnemyC" x="7955" y="4687" width="32" height="32"/>
+  <object id="283" name="Enemy" type="Enemy" x="4762" y="4673" width="32" height="32"/>
  </objectgroup>
 </map>

--- a/assets/textures/animations/EnemigoC.tsx
+++ b/assets/textures/animations/EnemigoC.tsx
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="1.11.2" name="EnemigoC" tilewidth="128" tileheight="128" tilecount="14" columns="14">
+ <image source="../spritesheets/SS enemics C/spritesheet_bloc_walking.png" width="1792" height="128"/>
+ <tile id="0" type="EnemyC"/>
+ <tile id="1" type="EnemyC"/>
+</tileset>

--- a/assets/textures/animations/ProjectileAnim.tsx
+++ b/assets/textures/animations/ProjectileAnim.tsx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.10" tiledversion="1.11.2" name="ProjectileAnim" tilewidth="64" tileheight="64" tilecount="15" columns="15">
+ <image source="../spritesheets/SS enemics C/spritesheet_pilota.png" width="960" height="64"/>
+</tileset>

--- a/include/EnemyC.h
+++ b/include/EnemyC.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "Entity.h"
+#include "Animation.h"
+#include <box2d/box2d.h>
+#include <SDL3/SDL.h>
+#include "Pathfinding.h"
+
+struct SDL_Texture;
+
+class EnemyC : public Entity
+{
+public:
+	// FSM states
+	enum class State {
+		IDLE,
+		PATROL,
+		ALERT,
+		SHOOT,
+		FLEE
+	};
+
+	EnemyC();
+	virtual ~EnemyC();
+
+	bool Awake();
+	bool Start();
+	bool Update(float dt);
+	bool CleanUp();
+	bool Destroy();
+
+	void OnCollision(PhysBody* physA, PhysBody* physB);
+	void OnCollisionEnd(PhysBody* physA, PhysBody* physB);
+
+	void SetPosition(Vector2D pos);
+	Vector2D GetPosition();
+	void TakeDamage(int damage) override;
+
+public:
+	float speed = 1.5f;
+	SDL_Texture* texture = nullptr;
+	int texW = 128, texH = 128;
+	PhysBody* pbody = nullptr;
+
+private:
+	// FSM
+	void UpdateFSM(float dt);
+	void EnterState(State newState);
+
+	// Helpers
+	void PerformPathfinding();
+	void GetPhysicsValues();
+	void MoveToward(float targetX);
+	void MoveAwayFrom(float targetX);
+	void ApplyPhysics();
+	void Shoot();
+	void Draw(float dt);
+
+	int GetDistanceToPlayer() const;
+
+private:
+	State currentState_ = State::IDLE;
+	b2Vec2 velocity = { 0.0f, 0.0f };
+
+	AnimationSet anims;
+	std::shared_ptr<Pathfinding> pathfinding;
+
+	// FSM parameters
+	static constexpr int   DETECT_RANGE = 15;      // tiles (manhattan)
+	static constexpr int   SHOOT_RANGE = 10;        // tiles
+	static constexpr int   FLEE_RANGE = 4;          // tiles
+	static constexpr float PATROL_SPEED = 1.5f;
+	static constexpr float FLEE_SPEED = 3.0f;
+	static constexpr float SHOOT_COOLDOWN = 2000.0f; // ms
+	static constexpr float IDLE_DURATION = 1500.0f;  // ms before patrol
+
+	float shootCooldown_ = 0.0f;
+	float idleTimer_ = 0.0f;
+
+	// Patrol
+	float patrolOriginX_ = 0.0f;
+	float patrolDirection_ = 1.0f;
+	static constexpr float PATROL_RANGE = 100.0f; // px from origin
+
+	// Contact damage (same pattern as Enemy)
+	static constexpr float ATTACK_INTERVAL = 1000.0f;
+	bool    isContactWithPlayer_ = false;
+	float   attackCooldown_ = 0.0f;
+	Entity* playerListener_ = nullptr;
+
+	// Facing
+	bool facingRight_ = false;
+};

--- a/include/Entity.h
+++ b/include/Entity.h
@@ -8,6 +8,8 @@ enum class EntityType
 	PLAYER,
 	ITEM,
 	ENEMY,
+	ENEMY_C,
+	PROJECTILE,
 	CHECKPOINT,
 	BOX,
 	UNKNOWN

--- a/include/Physics.h
+++ b/include/Physics.h
@@ -32,6 +32,7 @@ enum class ColliderType {
     LEDGE,
     CHECKPOINT,
     BOX,
+    PROJECTILE,
     UNKNOWN
     // ..
 };

--- a/include/Projectile.h
+++ b/include/Projectile.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "Entity.h"
+#include "Animation.h"
+#include <box2d/box2d.h>
+#include <SDL3/SDL.h>
+
+struct SDL_Texture;
+
+class Projectile : public Entity
+{
+public:
+	Projectile();
+	virtual ~Projectile();
+
+	bool Start();
+	bool Update(float dt);
+	bool CleanUp();
+	bool Destroy();
+
+	void OnCollision(PhysBody* physA, PhysBody* physB);
+	void OnCollisionEnd(PhysBody* physA, PhysBody* physB);
+
+	void SetPosition(Vector2D pos);
+	Vector2D GetPosition();
+
+	// Set the direction the projectile flies in (normalized)
+	void SetDirection(float dirX, float dirY);
+
+public:
+	SDL_Texture* texture = nullptr;
+	PhysBody* pbody = nullptr;
+
+private:
+	static constexpr float SPEED = 5.0f;
+	static constexpr float MAX_LIFETIME = 3000.0f; // ms
+	static constexpr int   PROJ_SIZE = 16;          // AABB half-size for physics
+	static constexpr float DRAW_SCALE = 0.5f;       // 64 * 0.5 = 32px on screen
+
+	float dirX_ = 1.0f;
+	float dirY_ = 0.0f;
+	float lifetime_ = 0.0f;
+
+	AnimationSet anims;
+	int texW = 64;
+	int texH = 64;
+};

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -60,7 +60,7 @@ bool Enemy::Update(float dt)
 {
 	ZoneScoped;
 	
-	if (Engine::GetInstance().scene->isPaused_) {
+	if (Engine::GetInstance().scene->isPaused_ || Engine::GetInstance().scene->isGameOver_) {
 		Draw(0.0f);
 		return true;
 	}

--- a/src/EnemyC.cpp
+++ b/src/EnemyC.cpp
@@ -1,0 +1,458 @@
+#include "EnemyC.h"
+#include "Engine.h"
+#include "Textures.h"
+#include "Audio.h"
+#include "Input.h"
+#include "Render.h"
+#include "Scene.h"
+#include "Log.h"
+#include "Physics.h"
+#include "EntityManager.h"
+#include "Map.h"
+#include "Projectile.h"
+#include "tracy/Tracy.hpp"
+
+EnemyC::EnemyC() : Entity(EntityType::ENEMY_C)
+{
+	name = "EnemyC";
+}
+
+EnemyC::~EnemyC() {}
+
+bool EnemyC::Awake() {
+	return true;
+}
+
+bool EnemyC::Start() {
+
+	// Load walking animation from the TSX (no <animation> nodes, use sequential loader)
+	anims.LoadSequentialFromTSX("assets/textures/animations/EnemigoC.tsx", "walk", 100);
+	anims.SetCurrent("walk");
+	anims.SetLoop("walk", true);
+
+	texture = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS enemics C/spritesheet_bloc_walking.png");
+
+	// Physics body
+	texW = 128;
+	texH = 128;
+	pbody = Engine::GetInstance().physics->CreateCapsule(
+		(int)position.getX() + texW / 2, (int)position.getY() + texH / 2,
+		20, 50, bodyType::DYNAMIC);
+
+	pbody->listener = this;
+	pbody->ctype = ColliderType::ENEMY;
+
+	// Initialize pathfinding
+	pathfinding = std::make_shared<Pathfinding>();
+	Vector2D pos = GetPosition();
+	Vector2D tilePos = Engine::GetInstance().map->WorldToMap((int)pos.getX(), (int)pos.getY() + 1);
+	pathfinding->ResetPath(tilePos);
+
+	// Remember patrol origin
+	patrolOriginX_ = position.getX();
+
+	// Start in IDLE
+	currentState_ = State::IDLE;
+	idleTimer_ = 0.0f;
+
+	return true;
+}
+
+bool EnemyC::Update(float dt)
+{
+	ZoneScoped;
+
+	if (Engine::GetInstance().scene->isPaused_ || Engine::GetInstance().scene->isGameOver_) {
+		Draw(0.0f);
+		return true;
+	}
+
+	// Tick cooldowns
+	if (shootCooldown_ > 0.0f) shootCooldown_ -= dt;
+	if (attackCooldown_ > 0.0f) attackCooldown_ -= dt;
+
+	// Contact damage while touching player
+	if (isContactWithPlayer_ && playerListener_ != nullptr && attackCooldown_ <= 0.0f)
+	{
+		playerListener_->TakeDamage(1);
+		attackCooldown_ = ATTACK_INTERVAL;
+	}
+
+	// FSM
+	UpdateFSM(dt);
+
+	Draw(dt);
+
+	return true;
+}
+
+int EnemyC::GetDistanceToPlayer() const
+{
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+	Vector2D tilePos = Engine::GetInstance().map->WorldToMap(bodyX, bodyY);
+
+	Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+	Vector2D playerTilePos = Engine::GetInstance().map->WorldToMap((int)playerPos.getX(), (int)playerPos.getY());
+
+	return std::abs((int)tilePos.getX() - (int)playerTilePos.getX()) +
+		std::abs((int)tilePos.getY() - (int)playerTilePos.getY());
+}
+
+void EnemyC::UpdateFSM(float dt)
+{
+	int dist = GetDistanceToPlayer();
+
+	switch (currentState_)
+	{
+	case State::IDLE:
+	{
+		// Stand still
+		GetPhysicsValues();
+		velocity.x = 0.0f;
+		ApplyPhysics();
+
+		idleTimer_ += dt;
+
+		// Transition to PATROL after idle duration
+		if (idleTimer_ >= IDLE_DURATION) {
+			EnterState(State::PATROL);
+		}
+		// Transition to ALERT if player detected
+		if (dist <= DETECT_RANGE) {
+			EnterState(State::ALERT);
+		}
+		break;
+	}
+
+	case State::PATROL:
+	{
+		GetPhysicsValues();
+
+		// Simple back-and-forth patrol
+		int bodyX, bodyY;
+		pbody->GetPosition(bodyX, bodyY);
+
+		float offsetFromOrigin = (float)bodyX - patrolOriginX_;
+
+		if (patrolDirection_ > 0.0f && offsetFromOrigin > PATROL_RANGE) {
+			patrolDirection_ = -1.0f;
+		}
+		else if (patrolDirection_ < 0.0f && offsetFromOrigin < -PATROL_RANGE) {
+			patrolDirection_ = 1.0f;
+		}
+
+		velocity.x = patrolDirection_ * PATROL_SPEED;
+		facingRight_ = (velocity.x > 0.0f);
+		ApplyPhysics();
+
+		// Transition to ALERT if player detected
+		if (dist <= DETECT_RANGE) {
+			EnterState(State::ALERT);
+		}
+		break;
+	}
+
+	case State::ALERT:
+	{
+		// Perform pathfinding toward player
+		PerformPathfinding();
+		GetPhysicsValues();
+
+		// Check transitions
+		if (dist > DETECT_RANGE) {
+			EnterState(State::IDLE);
+			break;
+		}
+
+		if (dist <= FLEE_RANGE) {
+			EnterState(State::FLEE);
+			break;
+		}
+
+		if (dist <= SHOOT_RANGE && shootCooldown_ <= 0.0f) {
+			EnterState(State::SHOOT);
+			break;
+		}
+
+		// Move toward player (slowly)
+		Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+		MoveToward(playerPos.getX());
+		ApplyPhysics();
+		break;
+	}
+
+	case State::SHOOT:
+	{
+		GetPhysicsValues();
+		velocity.x = 0.0f; // Stand still to shoot
+		ApplyPhysics();
+
+		// Face player
+		Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+		int bodyX, bodyY;
+		pbody->GetPosition(bodyX, bodyY);
+		facingRight_ = (playerPos.getX() > (float)bodyX);
+
+		// Shoot
+		Shoot();
+		shootCooldown_ = SHOOT_COOLDOWN;
+
+		// After shooting, go back to ALERT
+		EnterState(State::ALERT);
+		break;
+	}
+
+	case State::FLEE:
+	{
+		PerformPathfinding();
+		GetPhysicsValues();
+
+		// Check transitions
+		if (dist > DETECT_RANGE) {
+			EnterState(State::IDLE);
+			break;
+		}
+
+		if (dist > FLEE_RANGE) {
+			EnterState(State::ALERT);
+			break;
+		}
+
+		// Move away from player
+		Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+		MoveAwayFrom(playerPos.getX());
+
+		// Can still shoot while fleeing
+		if (shootCooldown_ <= 0.0f) {
+			Shoot();
+			shootCooldown_ = SHOOT_COOLDOWN;
+		}
+
+		ApplyPhysics();
+		break;
+	}
+	}
+}
+
+void EnemyC::EnterState(State newState)
+{
+	currentState_ = newState;
+
+	switch (newState)
+	{
+	case State::IDLE:
+		idleTimer_ = 0.0f;
+		break;
+	case State::PATROL:
+		speed = PATROL_SPEED;
+		break;
+	case State::ALERT:
+		speed = PATROL_SPEED;
+		break;
+	case State::SHOOT:
+		break;
+	case State::FLEE:
+		speed = FLEE_SPEED;
+		break;
+	}
+}
+
+void EnemyC::PerformPathfinding()
+{
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+	Vector2D tilePos = Engine::GetInstance().map->WorldToMap(bodyX, bodyY);
+
+	Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+	Vector2D playerTilePos = Engine::GetInstance().map->WorldToMap((int)playerPos.getX(), (int)playerPos.getY());
+
+	int dist = std::abs((int)tilePos.getX() - (int)playerTilePos.getX()) +
+		std::abs((int)tilePos.getY() - (int)playerTilePos.getY());
+
+	if (dist > 25) {
+		pathfinding->pathTiles.clear();
+		return;
+	}
+
+	pathfinding->ResetPath(tilePos);
+
+	while (pathfinding->CanPropagateAStar(tilePos)) {
+		pathfinding->PropagateAStar(SQUARED);
+	}
+}
+
+void EnemyC::GetPhysicsValues()
+{
+	velocity = Engine::GetInstance().physics->GetLinearVelocity(pbody);
+	velocity.x = 0.0f;
+}
+
+void EnemyC::MoveToward(float targetX)
+{
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+
+	const float POSITION_TOLERANCE = 2.0f;
+	if (targetX > bodyX + POSITION_TOLERANCE) {
+		velocity.x = speed;
+		facingRight_ = true;
+	}
+	else if (targetX < bodyX - POSITION_TOLERANCE) {
+		velocity.x = -speed;
+		facingRight_ = false;
+	}
+	else {
+		velocity.x = 0.0f;
+	}
+}
+
+void EnemyC::MoveAwayFrom(float targetX)
+{
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+
+	// Move in opposite direction from target
+	if (targetX > bodyX) {
+		velocity.x = -FLEE_SPEED;
+		facingRight_ = false;
+	}
+	else {
+		velocity.x = FLEE_SPEED;
+		facingRight_ = true;
+	}
+}
+
+void EnemyC::ApplyPhysics()
+{
+	Engine::GetInstance().physics->SetLinearVelocity(pbody, velocity);
+}
+
+void EnemyC::Shoot()
+{
+	// Create a projectile aimed at the player
+	auto projEntity = Engine::GetInstance().entityManager->CreateEntity(EntityType::PROJECTILE);
+	auto proj = std::dynamic_pointer_cast<Projectile>(projEntity);
+
+	if (proj) {
+		int bodyX, bodyY;
+		pbody->GetPosition(bodyX, bodyY);
+
+		// GetPlayerPosition returns top-left of sprite; offset to body center
+		Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+		float playerCenterX = playerPos.getX() + 64.0f;
+		float playerCenterY = playerPos.getY() + 64.0f;
+
+		float dirX = playerCenterX - (float)bodyX;
+		float dirY = playerCenterY - (float)bodyY;
+
+		proj->SetDirection(dirX, dirY);
+		proj->position = Vector2D((float)bodyX, (float)bodyY);
+		proj->Start();
+
+		LOG("EnemyC fired projectile toward player");
+	}
+}
+
+void EnemyC::Draw(float dt)
+{
+	anims.Update(dt);
+	const SDL_Rect& animFrame = anims.GetCurrentFrame();
+
+	int x, y;
+	pbody->GetPosition(x, y);
+	position.setX((float)x);
+	position.setY((float)y);
+
+	// Draw pathfinding debug
+	if (Engine::GetInstance().physics->IsDebug())
+		pathfinding->DrawPath();
+
+	// Flip based on facing direction (sprite natively faces left, so invert)
+	SDL_FlipMode flip = facingRight_ ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE;
+
+	// Offset Y upward by 20px so feet don't clip through the floor
+	Engine::GetInstance().render->DrawTexture(texture, x - texW / 2, y - texH / 2 - 20, &animFrame,
+		1.0f, 0, INT_MAX, INT_MAX, flip);
+}
+
+bool EnemyC::CleanUp()
+{
+	LOG("Cleanup EnemyC");
+	if (texture) {
+		Engine::GetInstance().textures->UnLoad(texture);
+		texture = nullptr;
+	}
+	if (pbody) {
+		Engine::GetInstance().physics->DeletePhysBody(pbody);
+		pbody = nullptr;
+	}
+	return true;
+}
+
+bool EnemyC::Destroy()
+{
+	LOG("Destroying EnemyC");
+	active = false;
+	pendingToDelete = true;
+	return true;
+}
+
+void EnemyC::SetPosition(Vector2D pos) {
+	pbody->SetPosition((int)(pos.getX()), (int)(pos.getY()));
+}
+
+Vector2D EnemyC::GetPosition() {
+	int x, y;
+	pbody->GetPosition(x, y);
+	return Vector2D((float)x - texW / 2, (float)y - texH / 2);
+}
+
+void EnemyC::OnCollision(PhysBody* physA, PhysBody* physB)
+{
+	if (physB->ctype == ColliderType::ATTACK)
+	{
+		LOG("EnemyC hit by player attack");
+		TakeDamage(1);
+	}
+	else if (physB->ctype == ColliderType::PLAYER)
+	{
+		isContactWithPlayer_ = true;
+		playerListener_ = physB->listener;
+		if (attackCooldown_ <= 0.0f)
+		{
+			playerListener_->TakeDamage(1);
+			attackCooldown_ = ATTACK_INTERVAL;
+		}
+	}
+}
+
+void EnemyC::OnCollisionEnd(PhysBody* physA, PhysBody* physB)
+{
+	if (physB->ctype == ColliderType::PLAYER)
+	{
+		isContactWithPlayer_ = false;
+		playerListener_ = nullptr;
+	}
+}
+
+void EnemyC::TakeDamage(int damage)
+{
+	health -= damage;
+	LOG("EnemyC took %d damage -> health: %d/%d", damage, health, maxHealth);
+
+	// Knockback
+	Vector2D playerPos = Engine::GetInstance().scene->GetPlayerPosition();
+	int bodyX, bodyY;
+	pbody->GetPosition(bodyX, bodyY);
+
+	float dirX = (bodyX > playerPos.getX()) ? 1.0f : -1.0f;
+	Engine::GetInstance().physics->ApplyLinearImpulseToCenter(pbody, dirX * 5.0f, -3.0f, true);
+
+	if (health <= 0)
+	{
+		health = 0;
+		LOG("EnemyC is dead");
+		Destroy();
+	}
+}

--- a/src/EntityManager.cpp
+++ b/src/EntityManager.cpp
@@ -6,6 +6,8 @@
 #include "Log.h"
 #include "Item.h"
 #include "Enemy.h"
+#include "EnemyC.h"
+#include "Projectile.h"
 #include "Checkpoint.h"
 #include "Box.h"
 #include "tracy/Tracy.hpp"
@@ -78,6 +80,12 @@ std::shared_ptr<Entity> EntityManager::CreateEntity(EntityType type)
 		break;
 	case EntityType::ENEMY:
 		entity = std::make_shared<Enemy>();
+		break;
+	case EntityType::ENEMY_C:
+		entity = std::make_shared<EnemyC>();
+		break;
+	case EntityType::PROJECTILE:
+		entity = std::make_shared<Projectile>();
 		break;
 	case EntityType::CHECKPOINT:
 		entity = std::make_shared<Checkpoint>();

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -6,6 +6,7 @@
 #include "Physics.h"
 #include "EntityManager.h"
 #include "Enemy.h"
+#include "EnemyC.h"
 #include "Checkpoint.h"
 #include "Box.h"
 #include "Window.h"
@@ -522,6 +523,12 @@ void Map::LoadEntities(std::shared_ptr<Player>& player) {
                     enemy->position = Vector2D(x, y);
                     enemy->Start();
                     LOG("Enemy spawned at: %f, %f", x, y);
+                }
+                else if (entityType == "EnemyC") {
+                    auto enemyC = std::dynamic_pointer_cast<EnemyC>(Engine::GetInstance().entityManager->CreateEntity(EntityType::ENEMY_C));
+                    enemyC->position = Vector2D(x, y);
+                    enemyC->Start();
+                    LOG("EnemyC spawned at: %f, %f", x, y);
                 }
                 else if (entityType == "Checkpoint") {
                     auto checkpoint = std::dynamic_pointer_cast<Checkpoint>(Engine::GetInstance().entityManager->CreateEntity(EntityType::CHECKPOINT));

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -531,6 +531,11 @@ void Player::OnCollision(PhysBody* physA, PhysBody* physB) {
 		Engine::GetInstance().audio->PlayFx(pickCoinFxId);
 		physB->listener->Destroy();
 		break;
+	case ColliderType::PROJECTILE:
+		TakeDamage(1);
+		if (physB->listener != nullptr)
+			physB->listener->Destroy();
+		break;
 	case ColliderType::UNKNOWN:
 		break;
 	default:

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -1,0 +1,152 @@
+#include "Projectile.h"
+#include "Engine.h"
+#include "Textures.h"
+#include "Render.h"
+#include "Physics.h"
+#include "Log.h"
+#include "EntityManager.h"
+#include "tracy/Tracy.hpp"
+#include "Scene.h"
+#include <cmath>
+
+Projectile::Projectile() : Entity(EntityType::PROJECTILE)
+{
+	name = "Projectile";
+}
+
+Projectile::~Projectile() {}
+
+bool Projectile::Start()
+{
+	// Load projectile animation from the spritesheet
+	anims.LoadSequentialFromTSX("assets/textures/animations/ProjectileAnim.tsx", "fly", 80);
+	anims.SetCurrent("fly");
+	anims.SetLoop("fly", true);
+
+	texture = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS enemics C/spritesheet_pilota.png");
+
+	// Create a sensor AABB for the projectile (sensor = no physical blocking, still triggers OnCollision)
+	pbody = Engine::GetInstance().physics->CreateRectangleSensor(
+		(int)position.getX(), (int)position.getY(),
+		PROJ_SIZE * 2, PROJ_SIZE * 2, bodyType::DYNAMIC);
+
+	pbody->listener = this;
+	pbody->ctype = ColliderType::PROJECTILE;
+
+	// Disable gravity for projectile (flies straight)
+	b2Body_SetGravityScale(pbody->body, 0.0f);
+
+	// Set initial velocity
+	Engine::GetInstance().physics->SetLinearVelocity(pbody, dirX_ * SPEED, dirY_ * SPEED);
+
+	return true;
+}
+
+bool Projectile::Update(float dt)
+{
+	ZoneScoped;
+
+	if (Engine::GetInstance().scene->isPaused_ || Engine::GetInstance().scene->isGameOver_) {
+		// Still draw but don't move
+		anims.Update(0.0f);
+		int x, y;
+		pbody->GetPosition(x, y);
+		int drawSize = (int)(texW * DRAW_SCALE);
+		const SDL_Rect& frame = anims.GetCurrentFrame();
+		Engine::GetInstance().render->DrawTexture(texture, x - drawSize / 2, y - drawSize / 2, &frame, 1.0f, 0, INT_MAX, INT_MAX, SDL_FLIP_NONE, DRAW_SCALE);
+		return true;
+	}
+
+	// Check lifetime
+	lifetime_ += dt;
+	if (lifetime_ >= MAX_LIFETIME) {
+		Destroy();
+		return true;
+	}
+
+	// Ensure velocity is maintained (in case physics slows it)
+	Engine::GetInstance().physics->SetLinearVelocity(pbody, dirX_ * SPEED, dirY_ * SPEED);
+
+	// Update animation
+	anims.Update(dt);
+	const SDL_Rect& frame = anims.GetCurrentFrame();
+
+	// Draw
+	int x, y;
+	pbody->GetPosition(x, y);
+	position.setX((float)x);
+	position.setY((float)y);
+
+	int drawSize = (int)(texW * DRAW_SCALE);
+	Engine::GetInstance().render->DrawTexture(texture, x - drawSize / 2, y - drawSize / 2, &frame, 1.0f, 0, INT_MAX, INT_MAX, SDL_FLIP_NONE, DRAW_SCALE);
+
+	return true;
+}
+
+void Projectile::OnCollision(PhysBody* physA, PhysBody* physB)
+{
+	switch (physB->ctype)
+	{
+	case ColliderType::PLAYER:
+		// Damage is handled by the Player's own OnCollision (ColliderType::PROJECTILE case)
+		LOG("Projectile hit player");
+		Destroy();
+		break;
+	case ColliderType::PLATFORM:
+		LOG("Projectile hit platform");
+		Destroy();
+		break;
+	default:
+		break;
+	}
+}
+
+void Projectile::OnCollisionEnd(PhysBody* physA, PhysBody* physB) {}
+
+bool Projectile::CleanUp()
+{
+	LOG("Cleanup projectile");
+	if (texture) {
+		Engine::GetInstance().textures->UnLoad(texture);
+		texture = nullptr;
+	}
+	if (pbody) {
+		Engine::GetInstance().physics->DeletePhysBody(pbody);
+		pbody = nullptr;
+	}
+	return true;
+}
+
+bool Projectile::Destroy()
+{
+	LOG("Destroying Projectile");
+	active = false;
+	pendingToDelete = true;
+	return true;
+}
+
+void Projectile::SetPosition(Vector2D pos)
+{
+	if (pbody) pbody->SetPosition((int)(pos.getX()), (int)(pos.getY()));
+}
+
+Vector2D Projectile::GetPosition()
+{
+	int x, y;
+	pbody->GetPosition(x, y);
+	return Vector2D((float)x, (float)y);
+}
+
+void Projectile::SetDirection(float dX, float dY)
+{
+	// Normalize direction
+	float len = std::sqrt(dX * dX + dY * dY);
+	if (len > 0.001f) {
+		dirX_ = dX / len;
+		dirY_ = dY / len;
+	}
+	else {
+		dirX_ = 1.0f;
+		dirY_ = 0.0f;
+	}
+}


### PR DESCRIPTION
Introduce a new EnemyC type (header + implementation) with FSM-based behavior (IDLE/PATROL/ALERT/SHOOT/FLEE), pathfinding support, shooting logic and contact damage. Add a Projectile entity (header + implementation) that flies toward the player, has a lifetime, sensor collision and rendering/animation. Integrate both into the engine: extend EntityType and ColliderType enums, register creation in EntityManager, spawn EnemyC from the map loader, handle PROJECTILE collisions in Player, and ensure Enemy respects game-over state. Also add TSX animation assets for EnemyC and Projectile and update the map template to place an EnemyC. Minor: bump tiled TSX version and object id in MapTemplate, and small Enemy Update guard to check isGameOver.

## Canvis
<!-- Descripció breu dels canvis -->

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [ ] El codi compila sense errors
- [ ] He provat els canvis localment
- [ ] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [ ] He usat Conventional Commits al títol del PR
- [ ] He enllaçat la Issue corresponent
