### PR TITLE
Add camera shake effect to renderer

### DIFF
--- a/include/Render.h
+++ b/include/Render.h
@@ -65,6 +65,7 @@ public:
 	void StartEyelidEffect(float duration);
 	void DrawEyelidEffect();
 	void SetCameraSway(bool active) { cameraSwayActive_ = active; }
+	void StartCameraShake(float durationMs, float intensity);
 
 	// Fade overlay system
 	void StartFade(FadeDirection dir, float durationMs);
@@ -151,4 +152,12 @@ private:
 
 	// Camera Sway
 	bool cameraSwayActive_ = false;
+
+	// Camera Shake
+	bool cameraShakeActive_ = false;
+	float cameraShakeDurationMs_ = 0.0f;
+	float cameraShakeElapsedMs_ = 0.0f;
+	float cameraShakeIntensity_ = 0.0f;
+	float cameraShakeOffsetX_ = 0.0f;
+	float cameraShakeOffsetY_ = 0.0f;
 };

--- a/src/MemoryFragment.cpp
+++ b/src/MemoryFragment.cpp
@@ -77,6 +77,7 @@ bool MemoryFragment::Update(float dt)
         if (sqrtf(dx * dx + dy * dy) < collectRange_)
         {
             fading_ = true;
+            Engine::GetInstance().render->StartCameraShake(600.0f, 15.0f);
             Engine::GetInstance().render->StartFade(FadeDirection::FADE_OUT, 600.0f);
             return true;
         }

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -138,6 +138,22 @@ bool Render::Update(float dt)
         }
     }
 
+    if (cameraShakeActive_) {
+        cameraShakeElapsedMs_ += dt;
+        if (cameraShakeElapsedMs_ >= cameraShakeDurationMs_) {
+            cameraShakeActive_ = false;
+            cameraShakeOffsetX_ = 0.0f;
+            cameraShakeOffsetY_ = 0.0f;
+        } else {
+            float progress = cameraShakeElapsedMs_ / cameraShakeDurationMs_;
+            float damping = 1.0f - progress;
+            float shakeX = (std::sin(totalTime_ * 50.0f) + std::cos(totalTime_ * 30.0f)) * 0.5f * cameraShakeIntensity_ * damping;
+            float shakeY = (std::cos(totalTime_ * 45.0f) + std::sin(totalTime_ * 35.0f)) * 0.5f * cameraShakeIntensity_ * damping;
+            cameraShakeOffsetX_ = shakeX;
+            cameraShakeOffsetY_ = shakeY;
+        }
+    }
+
 	return true;
 }
 
@@ -219,6 +235,14 @@ void Render::StartEyelidEffect(float duration)
     eyelidActive_ = true;
     eyelidElapsed_ = 0.0f;
     eyelidDuration_ = duration;
+}
+
+void Render::StartCameraShake(float durationMs, float intensity)
+{
+    cameraShakeActive_ = true;
+    cameraShakeDurationMs_ = durationMs;
+    cameraShakeElapsedMs_ = 0.0f;
+    cameraShakeIntensity_ = intensity;
 }
 
 void Render::FollowTarget(float dt)
@@ -308,9 +332,11 @@ bool Render::DrawTexture(SDL_Texture* texture, int x, int y, const SDL_Rect* sec
 	float scaleY = (drawScaleY > 0.0f) ? drawScaleY : drawScale;
 
 	SDL_FRect rect;
+	float camX = (float)camera.x + (speed != 0.0f ? cameraShakeOffsetX_ : 0.0f);
+	float camY = (float)camera.y + (speed != 0.0f ? cameraShakeOffsetY_ : 0.0f);
 	// Apply world-space zoom centered at the dynamic zoomCenter
-	rect.x = (float)((zoomCenterX + s * ((float)camera.x * speed + (float)x - zoomCenterX)) * scale);
-	rect.y = (float)((zoomCenterY + s * ((float)camera.y * speed + (float)y - zoomCenterY)) * scale);
+	rect.x = (float)((zoomCenterX + s * (camX * speed + (float)x - zoomCenterX)) * scale);
+	rect.y = (float)((zoomCenterY + s * (camY * speed + (float)y - zoomCenterY)) * scale);
 
 	if (section != NULL) {
 		rect.w = (float)(section->w * scale * drawScale * s);
@@ -353,8 +379,8 @@ bool Render::DrawRectangle(const SDL_Rect& rect, Uint8 r, Uint8 g, Uint8 b, Uint
 	SDL_SetRenderDrawColor(renderer, r, g, b, a);
 
 	SDL_FRect rec;
-	float camX = use_camera ? (float)camera.x : 0.0f;
-	float camY = use_camera ? (float)camera.y : 0.0f;
+	float camX = use_camera ? (float)camera.x + cameraShakeOffsetX_ : 0.0f;
+	float camY = use_camera ? (float)camera.y + cameraShakeOffsetY_ : 0.0f;
 	
 	// Apply world-space zoom centered at the dynamic zoomCenter
 	rec.x = (float)((zoomCenterX + s * (camX + (float)rect.x - zoomCenterX)) * scale);
@@ -375,8 +401,8 @@ bool Render::DrawLine(int x1, int y1, int x2, int y2, Uint8 r, Uint8 g, Uint8 b,
 
 	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 	SDL_SetRenderDrawColor(renderer, r, g, b, a);
-	float camX = use_camera ? (float)camera.x : 0.0f;
-	float camY = use_camera ? (float)camera.y : 0.0f;
+	float camX = use_camera ? (float)camera.x + cameraShakeOffsetX_ : 0.0f;
+	float camY = use_camera ? (float)camera.y + cameraShakeOffsetY_ : 0.0f;
 
 	float fx1 = (float)((zoomCenterX + s * (camX + (float)x1 - zoomCenterX)) * scale);
 	float fy1 = (float)((zoomCenterY + s * (camY + (float)y1 - zoomCenterY)) * scale);
@@ -396,8 +422,8 @@ bool Render::DrawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uin
 
 	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 	SDL_SetRenderDrawColor(renderer, r, g, b, a);
-	float camX = use_camera ? (float)camera.x : 0.0f;
-	float camY = use_camera ? (float)camera.y : 0.0f;
+	float camX = use_camera ? (float)camera.x + cameraShakeOffsetX_ : 0.0f;
+	float camY = use_camera ? (float)camera.y + cameraShakeOffsetY_ : 0.0f;
 
 	float cx = (float)((zoomCenterX + s * (camX + (float)x - zoomCenterX)) * scale);
 	float cy = (float)((zoomCenterY + s * (camY + (float)y - zoomCenterY)) * scale);
@@ -431,7 +457,7 @@ bool Render::DrawText(const char* text, int x, int y, int w, int h, SDL_Color co
 
 bool Render::IsOnScreenWorldRect(float x, float y, float w, float h, int margin) const
 {
-	float camX = -(float)camera.x, camY = -(float)camera.y;
+	float camX = -((float)camera.x + cameraShakeOffsetX_), camY = -((float)camera.y + cameraShakeOffsetY_);
 	float vW = GetWorldViewportWidth(), vH = GetWorldViewportHeight();
 	return !(x + w + margin < camX || x - margin > camX + vW || y + h + margin < camY || y - margin > camY + vH);
 }
@@ -737,8 +763,8 @@ void Render::DrawPlayerGlow(int worldX, int worldY, float radiusScale, Uint8 alp
 
 	SDL_FRect dst;
 	// Apply world-space zoom centered at the dynamic zoomCenter
-	dst.x = (float)((zoomCenterX + s * ((float)camera.x + (float)worldX - radius - zoomCenterX)) * scale);
-	dst.y = (float)((zoomCenterY + s * ((float)camera.y + (float)worldY - radius - zoomCenterY)) * scale);
+	dst.x = (float)((zoomCenterX + s * ((float)camera.x + cameraShakeOffsetX_ + (float)worldX - radius - zoomCenterX)) * scale);
+	dst.y = (float)((zoomCenterY + s * ((float)camera.y + cameraShakeOffsetY_ + (float)worldY - radius - zoomCenterY)) * scale);
 	dst.w = size * scale * s;
 	dst.h = size * scale * s;
 
@@ -756,8 +782,8 @@ void Render::DrawWhiteGlow(int worldX, int worldY, float radiusScale, Uint8 alph
 	float size = radius * 2.0f;
 
 	SDL_FRect dst;
-	dst.x = (float)((zoomCenterX + s * ((float)camera.x + (float)worldX - radius - zoomCenterX)) * scale);
-	dst.y = (float)((zoomCenterY + s * ((float)camera.y + (float)worldY - radius - zoomCenterY)) * scale);
+	dst.x = (float)((zoomCenterX + s * ((float)camera.x + cameraShakeOffsetX_ + (float)worldX - radius - zoomCenterX)) * scale);
+	dst.y = (float)((zoomCenterY + s * ((float)camera.y + cameraShakeOffsetY_ + (float)worldY - radius - zoomCenterY)) * scale);
 	dst.w = size * scale * s;
 	dst.h = size * scale * s;
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -4611,5 +4611,6 @@ void Scene::TriggerEndGameCinematic()
     // Stop the game music immediately and fade the screen to black.
     // The actual video is launched in UpdateBossFight() once the screen is fully black.
     Engine::GetInstance().audio->SetMusicVolume(0.0f);
+    Engine::GetInstance().render->StartCameraShake(1200.0f, 15.0f);
     Engine::GetInstance().render->StartFade(FadeDirection::FADE_OUT, 1200.0f);
 }


### PR DESCRIPTION
Introduce a camera shake system: add StartCameraShake API and per-instance state (active flag, duration, elapsed, intensity, offsets) to Render. Implement Update logic to advance and damp the shake over time using sine/cosine waves to compute X/Y offsets and provide StartCameraShake initializer. Apply the shake offsets to camera transforms used by DrawTexture, DrawRectangle, DrawLine, DrawCircle, IsOnScreenWorldRect, DrawPlayerGlow and DrawWhiteGlow so world-space rendering is affected. Trigger calls added where appropriate: MemoryFragment collection and the end-game cinematic now start a camera shake to provide visual feedback.

## Canvis
<!-- Descripció breu dels canvis -->

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [ ] El codi compila sense errors
- [ ] He provat els canvis localment
- [ ] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [ ] He usat Conventional Commits al títol del PR
- [ ] He enllaçat la Issue corresponent
