### PR TITLE
Use dedicated hide/exit animations (SS_Hide)

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -161,6 +161,9 @@ private:
 	bool  isHidingBehindRock_ = false;
 	// Visual: gentle alpha pulse while hidden to signal stealth state
 	float hideAlphaTime_ = 0.0f;
+	SDL_Texture* hideTexture_ = nullptr;
+	Animation    hideAnim_;      // frames 0→11: crouching
+	Animation    hideExitAnim_; // frames 11→0: standing up
 
 public:
 	void SetHidingBehindRock(bool hiding);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -78,6 +78,30 @@ bool Player::Start() {
 	texH = 128;
 	drawScale = 0.5f;
 
+	// Load individual hide animation
+	hideTexture_ = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS Individual/SS_Hide.png");
+	if (hideTexture_) {
+		int hideW = 0, hideH = 0;
+		Engine::GetInstance().textures->GetSize(hideTexture_, hideW, hideH);
+		int cols = 4;
+		int rows = 3;
+		int frameW = hideW / cols;
+		int frameH = hideH / rows;
+		int totalFrames = 12;
+		// Forward: crouching (frames 0 → 11)
+		for (int i = 0; i < totalFrames; ++i) {
+			SDL_Rect r = { (i % cols) * frameW, (i / cols) * frameH, frameW, frameH };
+			hideAnim_.AddFrame(r, 80);
+		}
+		hideAnim_.SetLoop(false);
+		// Reverse: standing up (frames 11 → 0)
+		for (int i = totalFrames - 1; i >= 0; --i) {
+			SDL_Rect r = { (i % cols) * frameW, (i / cols) * frameH, frameW, frameH };
+			hideExitAnim_.AddFrame(r, 80);
+		}
+		hideExitAnim_.SetLoop(false);
+	}
+
 	// Load push animation spritesheet (256x256 tiles, 5 columns, 20 frames)
 	pushTexture_ = Engine::GetInstance().textures->Load("assets/textures/spritesheets/SS Individual/spritesheetempujarcaja.png");
 	for (int i = 0; i < 20; ++i) {
@@ -617,7 +641,7 @@ void Player::Hide(float dt)
 	if (isWakingUp || isShowingDamageAnim_ || isDead_ || isYoyoTrapped_ || isDollGrabbed_) return;
 
 	auto& input = Engine::GetInstance().input;
-	bool hideDown = input->GetKey(SDL_SCANCODE_H) == KEY_DOWN ||
+	bool hideDown = input->GetKey(SDL_SCANCODE_E) == KEY_DOWN ||
 		input->GetGamepadButton(SDL_GAMEPAD_BUTTON_NORTH) == KEY_DOWN;
 
 	// Cannot hide without the blanket (cape collectible) or if it's not equipped
@@ -642,8 +666,7 @@ void Player::Hide(float dt)
 			isHiding_ = true;
 			velocity.x = 0.0f;
 			Engine::GetInstance().physics->SetXVelocity(pbody, 0.0f);
-			anims.SetCurrent("hide");
-			anims.ResetCurrent();
+			hideAnim_.Reset();
 			Engine::GetInstance().audio->PlayFx(capeFxId);
 			LOG("Player hiding");
 		}
@@ -651,7 +674,8 @@ void Player::Hide(float dt)
 		{
 			isHiding_ = false;
 			isExitingHide_ = true;
-			hideCooldown_ = HIDE_COOLDOWN; // cooldown starts on exit
+			hideExitAnim_.Reset(); // start stand-up animation from frame 0 (= crouched pose)
+			hideCooldown_ = HIDE_COOLDOWN;
 			Engine::GetInstance().audio->PlayFx(capeFxId);
 			LOG("Player exiting hide — cooldown started (%.0f ms)", HIDE_COOLDOWN);
 		}
@@ -660,21 +684,13 @@ void Player::Hide(float dt)
 	if (isHiding_)
 	{
 		velocity.x = 0.0f;
-		if (!anims.HasFinishedOnce("hide"))
-			anims.Update(dt);
+		// hideAnim_ is advanced in Draw() to avoid double-update
 	}
 
 	if (isExitingHide_)
 	{
 		velocity.x = 0.0f;
-		anims.UpdateBackwards(dt);
-
-		if (anims.GetCurrentFrameIndex() == 0)
-		{
-			isExitingHide_ = false;
-			anims.SetCurrent("idle");
-			LOG("Player stopped hiding");
-		}
+		// hideAnim_ is advanced backwards in Draw() to avoid double-update
 	}
 }
 
@@ -979,8 +995,29 @@ void Player::Draw(float dt) {
 	}
 	else if (isHiding_ || isHidingBehindRock_ || isExitingHide_)
 	{
-		// Hide animation is advanced inside Hide() — just grab the current frame
-		animFrame = &anims.GetCurrentFrame();
+		if (isExitingHide_)
+		{
+			// Stand-up: play hideExitAnim_ (= SS_Hide reversed) forward
+			hideExitAnim_.Update(dt);
+			animFrame = &hideExitAnim_.GetCurrentFrame();
+			LOG("ExitHide frame=%d w=%d h=%d", hideExitAnim_.GetCurrentFrameIndex(), animFrame->w, animFrame->h);
+			if (hideExitAnim_.HasFinishedOnce())
+			{
+				isExitingHide_ = false;
+				anims.SetCurrent("idle");
+				LOG("ExitHide done -> idle");
+			}
+		}
+		else
+		{
+			// Crouching: play hideAnim_ forward
+			if (!hideAnim_.HasFinishedOnce())
+				hideAnim_.Update(dt);
+			animFrame = &hideAnim_.GetCurrentFrame();
+		}
+		activeTex = hideTexture_;
+		float fw = static_cast<float>(animFrame ? animFrame->w : 0);
+		currentDrawScale = (fw > 0.0f) ? (128.0f / fw) : 0.5f;
 	}
 	else if (isPushing_ && velocity.x != 0.0f && !isJumping)
 	{
@@ -1586,12 +1623,13 @@ void Player::SetHidingBehindRock(bool hiding) {
 	if (hiding) {
 		velocity.x = 0.0f;
 		Engine::GetInstance().physics->SetXVelocity(pbody, 0.0f);
-		anims.SetCurrent("hide");
-		anims.ResetCurrent();
+		hideAnim_.Reset();
 		LOG("Player hiding behind rock");
 	} else {
-		anims.SetCurrent("idle");
-		LOG("Player stopped hiding behind rock");
+		// Play stand-up animation instead of snapping to idle
+		isExitingHide_ = true;
+		hideExitAnim_.Reset();
+		LOG("Player stopped hiding behind rock — playing stand-up anim");
 	}
 }
 


### PR DESCRIPTION
Introduce separate hideTexture_, hideAnim_ and hideExitAnim_ to drive crouch/stand-up sequences from assets/textures/spritesheets/SS Individual/SS_Hide.png. Build a 12-frame forward animation for crouching and a reversed sequence for standing up, load them in Start(), and advance frames in Draw() (forward for crouch, forward on the reversed exit animation) to avoid double-update. Swap the hide key from H to E, reset the appropriate Animation when entering/exiting hide, and play the stand-up animation when leaving a rock instead of snapping to idle. Adjust draw scaling to match hide frame width and update logging. These changes produce smoother hide/exit transitions and centralize hide visuals into a dedicated spritesheet.

## Canvis
Arreglo e implementacion de las animaciones de esconderse en la piedra

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [x] El codi compila sense errors
- [x] He provat els canvis localment
- [x] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [x] He usat Conventional Commits al títol del PR
- [x] He enllaçat la Issue corresponent
