### PR TITLE
Add credits video playback and skip cooldown

### DIFF
--- a/include/Scene.h
+++ b/include/Scene.h
@@ -327,6 +327,8 @@ private:
     // Boss death video — plays before the post-death map transition / music change
     bool        bossDeathVideoActive_  = false;
     bool        endGameVideoActive_    = false;
+    bool        creditsVideoActive_    = false;
+    float       videoSkipCooldown_     = 0.0f;
     bool        endGameFading_         = false;  // fade-out before final cinematic
     bool        endGameTriggered_      = false;  // true once end sequence fires; never reset
     bool        bossDeathFading_       = false;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -2111,6 +2111,9 @@ void Scene::UpdateGameplay(float dt)
 
 void Scene::UpdateBossFight(float dt)
 {
+    if (videoSkipCooldown_ > 0.0f) {
+        videoSkipCooldown_ -= dt;
+    }
     // ── End-game final cinematic: fade to black, play video, go to main menu ──
     if (endGameFading_)
     {
@@ -2127,10 +2130,13 @@ void Scene::UpdateBossFight(float dt)
     if (endGameVideoActive_)
     {
         auto& input = *Engine::GetInstance().input;
-        bool skipRequested = input.GetKey(SDL_SCANCODE_SPACE) == KEY_DOWN ||
-                             input.GetGamepadButton(SDL_GAMEPAD_BUTTON_SOUTH) == KEY_DOWN ||
-                             input.GetGamepadButton(SDL_GAMEPAD_BUTTON_START) == KEY_DOWN ||
-                             Engine::GetInstance().cinematics->HasSkipBeenRequested();
+        bool skipRequested = false;
+        if (videoSkipCooldown_ <= 0.0f) {
+            skipRequested = input.GetKey(SDL_SCANCODE_SPACE) == KEY_DOWN ||
+                            input.GetGamepadButton(SDL_GAMEPAD_BUTTON_SOUTH) == KEY_DOWN ||
+                            input.GetGamepadButton(SDL_GAMEPAD_BUTTON_START) == KEY_DOWN ||
+                            Engine::GetInstance().cinematics->HasSkipBeenRequested();
+        }
 
         if (skipRequested || !Engine::GetInstance().cinematics->IsPlaying())
         {
@@ -2138,6 +2144,41 @@ void Scene::UpdateBossFight(float dt)
                 Engine::GetInstance().cinematics->StopVideo();
             }
             endGameVideoActive_ = false;
+            
+            // Queue next video: Credits
+            creditsVideoActive_ = true;
+            videoSkipCooldown_ = 1000.0f; // 1 second cooldown
+            Engine::GetInstance().cinematics->PlayVideo("assets/video/Credits_Videos.mp4");
+            Engine::GetInstance().render->StartFade(FadeDirection::FADE_IN, 800.0f);
+        }
+        else 
+        {
+            // Draw "Press SPACE to Skip" overlay while playing
+            int winW = 0, winH = 0;
+            Engine::GetInstance().window->GetWindowSize(winW, winH);
+            SDL_Color skipColor = { 255, 255, 255, 120 };
+            Engine::GetInstance().render->DrawMenuTextCentered("Press SPACE to Skip", { winW - 300, winH - 60, 280, 30 }, skipColor, 0.4f);
+        }
+        return;
+    }
+
+    if (creditsVideoActive_)
+    {
+        auto& input = *Engine::GetInstance().input;
+        bool skipRequested = false;
+        if (videoSkipCooldown_ <= 0.0f) {
+            skipRequested = input.GetKey(SDL_SCANCODE_SPACE) == KEY_DOWN ||
+                            input.GetGamepadButton(SDL_GAMEPAD_BUTTON_SOUTH) == KEY_DOWN ||
+                            input.GetGamepadButton(SDL_GAMEPAD_BUTTON_START) == KEY_DOWN ||
+                            Engine::GetInstance().cinematics->HasSkipBeenRequested();
+        }
+
+        if (skipRequested || !Engine::GetInstance().cinematics->IsPlaying())
+        {
+            if (skipRequested) {
+                Engine::GetInstance().cinematics->StopVideo();
+            }
+            creditsVideoActive_ = false;
             
             // Queue immediate scene change to MAIN MENU
             hasPendingSceneChange = true;
@@ -3110,6 +3151,14 @@ void Scene::PostUpdateGameplay()
 	}
 	else if (isPaused_ && !showInventory_) {
 		DrawPauseMenu();
+	}
+
+	// Make sure the game is hidden while videos are playing
+	if (endGameVideoActive_ || creditsVideoActive_ || bossDeathVideoActive_) {
+		int winW = 0, winH = 0;
+		Engine::GetInstance().window->GetWindowSize(winW, winH);
+		SDL_Rect fullscreen = { 0, 0, winW, winH };
+		Engine::GetInstance().render->DrawRectangle(fullscreen, 0, 0, 0, 255, true, false);
 	}
 } 
 		// ── Inventory ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Rename the credits video asset and add runtime support to play it after the end-game cinematic. Introduces creditsVideoActive_ and videoSkipCooldown_ in Scene.h, decrements the cooldown in UpdateBossFight, and gates skip input until the cooldown expires. When the end-game video finishes, the credits video (assets/video/Credits_Videos.mp4) is queued and a fade is started; a "Press SPACE to Skip" overlay is drawn while playing. Credits playback can be skipped (or will auto-advance when finished) and transitions to the main menu. Also ensure the game view is hidden (full-screen black) while any cinematic video is playing.

## Canvis
creditos finales añadidos

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [x] El codi compila sense errors
- [x] He provat els canvis localment
- [x] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [x] He usat Conventional Commits al títol del PR
- [x] He enllaçat la Issue corresponent
