### PR TITLE
Hide player UI in Boss2 room

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -2751,7 +2751,7 @@ void Scene::PostUpdateGameplay()
 
 	// --- Draw Health HUD ---
 	if (player && !player->isWakingUp && !isPaused_ && !showInventory_ && !showMapViewer_
-		&& currentMapFile_ != "MapLvl2ZonaBoss.tmx") {
+		&& currentMapFile_ != "MapLvl2ZonaBoss.tmx" && currentMapFile_ != "MapLvl3ZonaBoss.tmx") {
 		SDL_Rect r;
 		const SDL_Rect* frame = nullptr;
 		SDL_Texture* texToDraw = nullptr;


### PR DESCRIPTION
## Canvis
Extend the same HUD-hiding condition used for Boss1's arena to Boss2's room (MapLvl3ZonaBoss.tmx).
## Issues relacionades
#369

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [x] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [x] El codi compila sense errors
- [x] He provat els canvis localment
- [x] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [x] He usat Conventional Commits al títol del PR
- [x] He enllaçat la Issue corresponent
