### PR TITLE
Add memory fragment collection & UI

### DIFF
--- a/assets/maps/MapTemplate.tmx
+++ b/assets/maps/MapTemplate.tmx
@@ -423,6 +423,7 @@
   <object id="1809" name="MemoryFragment" type="MemoryFragment" x="3784" y="2637" width="80" height="60">
    <properties>
     <property name="video_path" value="assets/video/Anchor_1.mp4"/>
+    <property name="fragment_id" type="int" value="0"/>
    </properties>
   </object>
   <object id="1811" name="HidingRock" type="HidingRock" x="6286.79" y="8529.7" width="64" height="64">

--- a/include/MemoryFragment.h
+++ b/include/MemoryFragment.h
@@ -17,6 +17,7 @@ public:
     void SetVideoPath(const std::string& path) { videoPath_ = path; }
     void SetCollectRange(float r)              { collectRange_ = r; }
     void SetScale(float s)                     { scale_ = s; }
+    void SetFragmentId(int id)                 { fragmentId_ = id; }
 
 private:
     void Draw();
@@ -30,6 +31,7 @@ private:
     std::string videoPath_    = "";
     float       collectRange_ = 100.0f;
     float       scale_        = 0.5f;   // 256 * 0.5 = 128px on screen
+    int         fragmentId_   = -1;
 
     // SS_Fragment_Collectible.png: 1536x1024 → 6 cols × 4 rows of 256×256 frames
     static constexpr int   COLS         = 6;

--- a/include/Player.h
+++ b/include/Player.h
@@ -68,6 +68,12 @@ public:
 	bool IsBearMode() const { return isBearMode_; }
 	bool IsBearModeActive() const { return isBearMode_ || isBearTransforming_ || isThrowingBear_ || isKidSleeping_; }
 
+	// Memory Fragments
+	bool HasMemoryFragment(int index) const { return index >= 0 && index < 3 ? hasMemoryFragment_[index] : false; }
+	void SetMemoryFragment(int index, bool v) { if (index >= 0 && index < 3) hasMemoryFragment_[index] = v; }
+	bool IsMemoryFragmentNew(int index) const { return index >= 0 && index < 3 ? isMemoryFragmentNew_[index] : false; }
+	void SetMemoryFragmentNew(int index, bool v) { if (index >= 0 && index < 3) isMemoryFragmentNew_[index] = v; }
+
 private:
 
 	void GetPhysicsValues();
@@ -193,6 +199,10 @@ private:
 	bool hasBlanket_ = false;
 	bool hasStuffedAnimal_ = false;
 	EquippedItem equippedItem_ = EquippedItem::NONE;
+
+	// Memory fragments
+	bool hasMemoryFragment_[3] = { false, false, false };
+	bool isMemoryFragmentNew_[3] = { false, false, false };
 
 	// Push rock state
 	bool  isPushing_ = false;

--- a/include/SaveSystem.h
+++ b/include/SaveSystem.h
@@ -25,6 +25,7 @@ struct GameState
 	bool playerHasBlanket = false;
 	bool playerHasSlingshot = false;
 	bool playerHasStuffedAnimal = false;
+	bool hasMemoryFragment[3] = { false, false, false };
 
 	// Checkpoint state
 	std::string activeCheckpointId;

--- a/include/Scene.h
+++ b/include/Scene.h
@@ -248,6 +248,12 @@ private:
     // ── Loading Screen ────────────────────────────────────────────────────────
     void LoadLoading();
     void UnloadLoading();
+    
+    // Persistent state across map loads
+    bool savedHasBlanket_ = false;
+    bool savedHasSlingshot_ = false;
+    bool savedHasStuffedAnimal_ = false;
+    bool savedFragments_[3] = {false, false, false};
     void UpdateLoading(float dt);
     void DrawLoading();
     float loadingTimer_ = 0.0f;
@@ -508,14 +514,17 @@ private:
 
     // ── Memories UI ───────────────────────────────────────────────────────────
     SDL_Texture* texMemoria1Base_ = nullptr;
+    SDL_Texture* texMemoria1Collected_ = nullptr;
     SDL_Texture* texMemoria1N1_ = nullptr;
     SDL_Texture* texMemoria1N2_ = nullptr;
 
     SDL_Texture* texMemoria2Base_ = nullptr;
+    SDL_Texture* texMemoria2Collected_ = nullptr;
     SDL_Texture* texMemoria2N1_ = nullptr;
     SDL_Texture* texMemoria2N2_ = nullptr;
 
     SDL_Texture* texMemoria3Base_ = nullptr;
+    SDL_Texture* texMemoria3Collected_ = nullptr;
     SDL_Texture* texMemoria3N1_ = nullptr;
     SDL_Texture* texMemoria3N2_ = nullptr;
     SDL_Texture* texMemoria3N3_ = nullptr;
@@ -532,6 +541,7 @@ private:
 
     // Hover fade states
     float memoryHoverTimers_[3] = { 0.0f, 0.0f, 0.0f };
+    float memoryNewAnimTimer_[3] = { 0.0f, 0.0f, 0.0f };
 
     // Fullscreen state
     bool showMemoryViewer_ = false;

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -1067,6 +1067,8 @@ void Map::LoadEntities(std::shared_ptr<Player> &player, bool portalTransition,
               frag->SetCollectRange(prop.attribute("value").as_float(100.0f));
             else if (pname == "scale")
               frag->SetScale(prop.attribute("value").as_float(0.5f));
+            else if (pname == "fragment_id")
+              frag->SetFragmentId(prop.attribute("value").as_int(-1));
           }
           frag->Start();
           LOG("MemoryFragment spawned at (%.0f, %.0f)", frag->position.getX(),

--- a/src/MemoryFragment.cpp
+++ b/src/MemoryFragment.cpp
@@ -7,6 +7,7 @@
 #include "Cinematics.h"
 #include "Log.h"
 #include <cmath>
+#include "Player.h"
 
 MemoryFragment::MemoryFragment() : Entity(EntityType::MEMORY_FRAGMENT)
 {
@@ -53,6 +54,16 @@ bool MemoryFragment::Update(float dt)
         {
             fading_    = false;
             collected_ = true;
+
+            // Set fragment in Player
+            if (fragmentId_ >= 0 && fragmentId_ < 3) {
+                auto& scn = *Engine::GetInstance().scene;
+                if (scn.player) {
+                    scn.player->SetMemoryFragment(fragmentId_, true);
+                    scn.player->SetMemoryFragmentNew(fragmentId_, true);
+                }
+            }
+
             if (!videoPath_.empty())
             {
                 Engine::GetInstance().cinematics->PlayVideo(videoPath_.c_str());

--- a/src/SaveSystem.cpp
+++ b/src/SaveSystem.cpp
@@ -268,6 +268,9 @@ void SaveSystem::CollectPlayerState()
 	gameState_.playerHasBlanket = scene->player ? scene->player->HasBlanket() : false;
 	gameState_.playerHasSlingshot = scene->player ? scene->player->HasSlingshot() : false;
 	gameState_.playerHasStuffedAnimal = scene->player ? scene->player->HasStuffedAnimal() : false;
+	for (int i = 0; i < 3; ++i) {
+		gameState_.hasMemoryFragment[i] = scene->player ? scene->player->HasMemoryFragment(i) : false;
+	}
 
 	if (pendingCheckpointPositionOverride_)
 	{
@@ -349,6 +352,10 @@ void SaveSystem::ApplyPlayerState()
 		scene->player->SetHasBlanket(gameState_.playerHasBlanket);
 		scene->player->SetHasSlingshot(gameState_.playerHasSlingshot);
 		scene->player->SetHasStuffedAnimal(gameState_.playerHasStuffedAnimal);
+		for (int i = 0; i < 3; ++i) {
+			scene->player->SetMemoryFragment(i, gameState_.hasMemoryFragment[i]);
+			scene->player->SetMemoryFragmentNew(i, false);
+		}
 		scene->player->Revive();
 		scene->ResetHealthUI(scene->player->health);
 	}
@@ -503,6 +510,10 @@ bool SaveSystem::WriteXML(const std::string& filename)
 	stateNode.append_attribute("hasBlanket") = gameState_.playerHasBlanket;
 	stateNode.append_attribute("hasSlingshot") = gameState_.playerHasSlingshot;
 	stateNode.append_attribute("hasStuffedAnimal") = gameState_.playerHasStuffedAnimal;
+	for (int i = 0; i < 3; ++i) {
+		std::string attrName = "hasMemoryFragment" + std::to_string(i);
+		stateNode.append_attribute(attrName.c_str()) = gameState_.hasMemoryFragment[i];
+	}
 
 	// Entities node (placeholder for future)
 	pugi::xml_node entitiesNode = root.append_child("entities");
@@ -577,6 +588,10 @@ bool SaveSystem::ReadXML(const std::string& filename)
 			gameState_.playerHasBlanket = stateNode.attribute("hasBlanket").as_bool(false);
 			gameState_.playerHasSlingshot = stateNode.attribute("hasSlingshot").as_bool(false);
 			gameState_.playerHasStuffedAnimal = stateNode.attribute("hasStuffedAnimal").as_bool(false);
+			for (int i = 0; i < 3; ++i) {
+				std::string attrName = "hasMemoryFragment" + std::to_string(i);
+				gameState_.hasMemoryFragment[i] = stateNode.attribute(attrName.c_str()).as_bool(false);
+			}
 		}
 	}
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1623,13 +1623,9 @@ void Scene::UpdateLoading(float dt)
 		else {
 			int index = targetLevelIndex_;
 			if (index >= 0 && (size_t)index < levels_.size()) {
-				bool savedHasBlanket = false, savedHasSlingshot = false, savedHasStuffedAnimal = false;
 				Player::EquippedItem eqItem = Player::EquippedItem::NONE;
 				int savedHealth = 0;
 				if (player) {
-					savedHasBlanket = player->HasBlanket();
-					savedHasSlingshot = player->HasSlingshot();
-					savedHasStuffedAnimal = player->HasStuffedAnimal();
 					eqItem = player->GetEquippedItem();
 					savedHealth = player->health;
 				}
@@ -1665,12 +1661,11 @@ void Scene::UpdateLoading(float dt)
 
 				player->Start();
 			}
-			healthSlotCount_ = currentLevelIndex_ + 3;
-			if (healthSlotCount_ > MAX_HEALTH_SLOTS) healthSlotCount_ = MAX_HEALTH_SLOTS;
 			if (player) {
-				player->SetHasBlanket(savedHasBlanket);
-				player->SetHasSlingshot(savedHasSlingshot);
-				player->SetHasStuffedAnimal(savedHasStuffedAnimal);
+				player->SetHasBlanket(savedHasBlanket_);
+				player->SetHasSlingshot(savedHasSlingshot_);
+				player->SetHasStuffedAnimal(savedHasStuffedAnimal_);
+				for(int i = 0; i < 3; i++) player->SetMemoryFragment(i, savedFragments_[i]);
 				player->SetEquippedItem(eqItem);
 				player->maxHealth = healthSlotCount_;
 				// For level transitions (not first load), preserve health up to the new max
@@ -1680,9 +1675,9 @@ void Scene::UpdateLoading(float dt)
 					player->health = healthSlotCount_;
 				}
 			}
-			if (savedHasBlanket) capaCollected_ = true;
-			if (savedHasSlingshot) slingshotCollected_ = true;
-			if (savedHasStuffedAnimal) stuffedAnimalCollected_ = true;
+			if (savedHasBlanket_) capaCollected_ = true;
+			if (savedHasSlingshot_) slingshotCollected_ = true;
+			if (savedHasStuffedAnimal_) stuffedAnimalCollected_ = true;
 			currentHealthUI_ = player ? player->health : healthSlotCount_;
 			activeHealthAnim_ = 0;
 			isGameOver_ = false;
@@ -2006,14 +2001,17 @@ void Scene::LoadGameplay()
 
 	// Memories UI textures
 	texMemoria1Base_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_1_Base.png");
+	texMemoria1Collected_ = Engine::GetInstance().textures->Load("assets/textures/Menu/UI_Memory_Fragment_1.2.png");
 	texMemoria1N1_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_1_N1.png");
 	texMemoria1N2_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_1_N2.png");
 
 	texMemoria2Base_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_2_Base.png");
+	texMemoria2Collected_ = Engine::GetInstance().textures->Load("assets/textures/Menu/UI_Memory_Fragment_2.2.png");
 	texMemoria2N1_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_2_N1.png");
 	texMemoria2N2_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_2_N2.png");
 
 	texMemoria3Base_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_3_Base.png");
+	texMemoria3Collected_ = Engine::GetInstance().textures->Load("assets/textures/Menu/UI_Memory_Fragment_3.1.png");
 	texMemoria3N1_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_3_N1.png");
 	texMemoria3N2_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_3_N2.png");
 	texMemoria3N3_ = Engine::GetInstance().textures->Load("assets/textures/UI/UI_Memoria_3_N3.png");
@@ -2904,6 +2902,13 @@ void Scene::UnloadGameplay()
 	isPuzzleMap3Lever_ = false;
 	isPuzzleMap3Buttons_ = false;
 
+	if (player) {
+		savedHasBlanket_ = player->HasBlanket();
+		savedHasSlingshot_ = player->HasSlingshot();
+		savedHasStuffedAnimal_ = player->HasStuffedAnimal();
+		for(int i = 0; i < 3; i++) savedFragments_[i] = player->HasMemoryFragment(i);
+	}
+
 	Engine::GetInstance().uiManager->CleanUp();
 	player.reset();
 	Engine::GetInstance().entityManager->CleanUp();
@@ -2960,14 +2965,17 @@ void Scene::UnloadGameplay()
 
 	// Unload Memories UI textures
 	if (texMemoria1Base_) { Engine::GetInstance().textures->UnLoad(texMemoria1Base_); texMemoria1Base_ = nullptr; }
+	if (texMemoria1Collected_) { Engine::GetInstance().textures->UnLoad(texMemoria1Collected_); texMemoria1Collected_ = nullptr; }
 	if (texMemoria1N1_) { Engine::GetInstance().textures->UnLoad(texMemoria1N1_); texMemoria1N1_ = nullptr; }
 	if (texMemoria1N2_) { Engine::GetInstance().textures->UnLoad(texMemoria1N2_); texMemoria1N2_ = nullptr; }
 
 	if (texMemoria2Base_) { Engine::GetInstance().textures->UnLoad(texMemoria2Base_); texMemoria2Base_ = nullptr; }
+	if (texMemoria2Collected_) { Engine::GetInstance().textures->UnLoad(texMemoria2Collected_); texMemoria2Collected_ = nullptr; }
 	if (texMemoria2N1_) { Engine::GetInstance().textures->UnLoad(texMemoria2N1_); texMemoria2N1_ = nullptr; }
 	if (texMemoria2N2_) { Engine::GetInstance().textures->UnLoad(texMemoria2N2_); texMemoria2N2_ = nullptr; }
 
 	if (texMemoria3Base_) { Engine::GetInstance().textures->UnLoad(texMemoria3Base_); texMemoria3Base_ = nullptr; }
+	if (texMemoria3Collected_) { Engine::GetInstance().textures->UnLoad(texMemoria3Collected_); texMemoria3Collected_ = nullptr; }
 	if (texMemoria3N1_) { Engine::GetInstance().textures->UnLoad(texMemoria3N1_); texMemoria3N1_ = nullptr; }
 	if (texMemoria3N2_) { Engine::GetInstance().textures->UnLoad(texMemoria3N2_); texMemoria3N2_ = nullptr; }
 	if (texMemoria3N3_) { Engine::GetInstance().textures->UnLoad(texMemoria3N3_); texMemoria3N3_ = nullptr; }
@@ -3588,6 +3596,7 @@ void Scene::PostUpdateGameplay()
 
 				bool isEnemy = false;
 				bool isCheckpoint = false;
+				bool isMemoryFragment = false;
 
 				switch (entity->type)
 				{
@@ -3607,11 +3616,14 @@ void Scene::PostUpdateGameplay()
 				case EntityType::CHECKPOINT:
 					isCheckpoint = true;
 					break;
+				case EntityType::MEMORY_FRAGMENT:
+					isMemoryFragment = true;
+					break;
 				default:
 					break;
 				}
 
-				if (isEnemy || isCheckpoint)
+				if (isEnemy || isCheckpoint || isMemoryFragment)
 				{
 					Vector2D entityPos = entity->GetPosition();
 					float offsetWorldX = entityPos.getX() - pWorldX;
@@ -3652,6 +3664,14 @@ void Scene::PostUpdateGameplay()
 							render.DrawRectangle(dot, 255, 30, 30, blinkAlpha, true, false);
 							SDL_Rect dotOutline = { drawX - 5, drawY - 5, 10, 10 };
 							render.DrawRectangle(dotOutline, 0, 0, 0, 200, false, false);
+						}
+						else if (isMemoryFragment)
+						{
+							SDL_Rect dot = { drawX - 3, drawY - 3, 6, 6 }; 
+							// Mysterious pale white/blue color with blinking effect
+							render.DrawRectangle(dot, 220, 240, 255, blinkAlpha, true, false);
+							SDL_Rect dotOutline = { drawX - 4, drawY - 4, 8, 8 };
+							render.DrawRectangle(dotOutline, 200, 230, 255, 200, false, false);
 						}
 					}
 				}
@@ -4151,7 +4171,7 @@ void Scene::DrawInventory(int winW, int winH)
 
 	// Fragment 2 (right): portrait, overlaps fragment 1 on the right side
 	float x2 = cX + w2 * 0.05f;
-	float y2 = cY - h2 * 0.65f;
+	float y2 = cY - h2 * 0.65f + 5.0f;
 
 	// Fragment 3 (bottom): landscape, below and overlapping both
 	float x3 = cX - w3 * 0.73f;
@@ -4200,6 +4220,20 @@ void Scene::DrawInventory(int winW, int winH)
 		}
 	}
 
+	for (int i = 0; i < 3; i++) {
+		if (player && player->IsMemoryFragmentNew(i)) {
+			memoryNewAnimTimer_[i] += 0.0005f * invDt; // Slow fade
+			if (memoryNewAnimTimer_[i] >= 1.0f) {
+				memoryNewAnimTimer_[i] = 1.0f;
+				player->SetMemoryFragmentNew(i, false);
+			}
+		} else if (player && player->HasMemoryFragment(i)) {
+			memoryNewAnimTimer_[i] = 1.0f;
+		} else {
+			memoryNewAnimTimer_[i] = 0.0f;
+		}
+	}
+
 	// Trigger full screen click handlers
 	if (input->GetMouseButtonDown(SDL_BUTTON_LEFT) == KEY_DOWN && !showMemoryViewer_)
 	{
@@ -4231,14 +4265,20 @@ void Scene::DrawInventory(int winW, int winH)
 	if (texMemoria1Base_)
 	{
 		render.DrawTextureAlphaF(texMemoria1Base_, rect1.x, rect1.y, rect1.w, rect1.h, 255);
-		if (texMemoria1N1_ && texMemoria1N2_) {
-			Uint8 alphaN1 = (Uint8)((1.0f - memoryHoverTimers_[0]) * 255.0f);
-			Uint8 alphaN2 = (Uint8)(memoryHoverTimers_[0] * 255.0f);
-			if (alphaN1 > 0) render.DrawTextureAlphaF(texMemoria1N1_, rect1.x, rect1.y, rect1.w, rect1.h, alphaN1);
-			if (alphaN2 > 0) render.DrawTextureAlphaF(texMemoria1N2_, rect1.x, rect1.y, rect1.w, rect1.h, alphaN2);
-		} else if (hover1) {
-			SDL_Rect r1 = { (int)rect1.x, (int)rect1.y, (int)rect1.w, (int)rect1.h };
-			render.DrawRectangle(r1, 255, 255, 255, 60, false, false);
+		bool hasFrag = player && player->HasMemoryFragment(0);
+		if (hasFrag && texMemoria1Collected_) {
+			Uint8 alpha = (Uint8)(memoryNewAnimTimer_[0] * 255.0f);
+			if (alpha > 0) render.DrawTextureAlphaF(texMemoria1Collected_, rect1.x, rect1.y, rect1.w, rect1.h, alpha);
+		} else {
+			if (texMemoria1N1_ && texMemoria1N2_) {
+				Uint8 alphaN1 = (Uint8)((1.0f - memoryHoverTimers_[0]) * 255.0f);
+				Uint8 alphaN2 = (Uint8)(memoryHoverTimers_[0] * 255.0f);
+				if (alphaN1 > 0) render.DrawTextureAlphaF(texMemoria1N1_, rect1.x, rect1.y, rect1.w, rect1.h, alphaN1);
+				if (alphaN2 > 0) render.DrawTextureAlphaF(texMemoria1N2_, rect1.x, rect1.y, rect1.w, rect1.h, alphaN2);
+			} else if (hover1) {
+				SDL_Rect r1 = { (int)rect1.x, (int)rect1.y, (int)rect1.w, (int)rect1.h };
+				render.DrawRectangle(r1, 255, 255, 255, 60, false, false);
+			}
 		}
 	}
 
@@ -4246,14 +4286,20 @@ void Scene::DrawInventory(int winW, int winH)
 	if (texMemoria2Base_)
 	{
 		render.DrawTextureAlphaF(texMemoria2Base_, rect2.x, rect2.y, rect2.w, rect2.h, 255);
-		if (texMemoria2N1_ && texMemoria2N2_) {
-			Uint8 alphaN1 = (Uint8)((1.0f - memoryHoverTimers_[1]) * 255.0f);
-			Uint8 alphaN2 = (Uint8)(memoryHoverTimers_[1] * 255.0f);
-			if (alphaN1 > 0) render.DrawTextureAlphaF(texMemoria2N1_, rect2.x, rect2.y, rect2.w, rect2.h, alphaN1);
-			if (alphaN2 > 0) render.DrawTextureAlphaF(texMemoria2N2_, rect2.x, rect2.y, rect2.w, rect2.h, alphaN2);
-		} else if (hover2) {
-			SDL_Rect r2 = { (int)rect2.x, (int)rect2.y, (int)rect2.w, (int)rect2.h };
-			render.DrawRectangle(r2, 255, 255, 255, 60, false, false);
+		bool hasFrag = player && player->HasMemoryFragment(1);
+		if (hasFrag && texMemoria2Collected_) {
+			Uint8 alpha = (Uint8)(memoryNewAnimTimer_[1] * 255.0f);
+			if (alpha > 0) render.DrawTextureAlphaF(texMemoria2Collected_, rect2.x, rect2.y, rect2.w, rect2.h, alpha);
+		} else {
+			if (texMemoria2N1_ && texMemoria2N2_) {
+				Uint8 alphaN1 = (Uint8)((1.0f - memoryHoverTimers_[1]) * 255.0f);
+				Uint8 alphaN2 = (Uint8)(memoryHoverTimers_[1] * 255.0f);
+				if (alphaN1 > 0) render.DrawTextureAlphaF(texMemoria2N1_, rect2.x, rect2.y, rect2.w, rect2.h, alphaN1);
+				if (alphaN2 > 0) render.DrawTextureAlphaF(texMemoria2N2_, rect2.x, rect2.y, rect2.w, rect2.h, alphaN2);
+			} else if (hover2) {
+				SDL_Rect r2 = { (int)rect2.x, (int)rect2.y, (int)rect2.w, (int)rect2.h };
+				render.DrawRectangle(r2, 255, 255, 255, 60, false, false);
+			}
 		}
 	}
 
@@ -4261,36 +4307,42 @@ void Scene::DrawInventory(int winW, int winH)
 	if (texMemoria3Base_)
 	{
 		render.DrawTextureAlphaF(texMemoria3Base_, rect3.x, rect3.y, rect3.w, rect3.h, 255);
-		if (texMemoria3N1_ && texMemoria3N2_ && texMemoria3N3_) {
-			float t = memoryHoverTimers_[2];
-			float a1 = 255.0f, a2 = 0.0f, a3 = 0.0f;
-			if (t > 0.0f)
-			{
-				if (t <= 1.0f) {
-					a1 = (1.0f - t) * 255.0f;
-					a2 = t * 255.0f;
-					a3 = 0.0f;
+		bool hasFrag = player && player->HasMemoryFragment(2);
+		if (hasFrag && texMemoria3Collected_) {
+			Uint8 alpha = (Uint8)(memoryNewAnimTimer_[2] * 255.0f);
+			if (alpha > 0) render.DrawTextureAlphaF(texMemoria3Collected_, rect3.x, rect3.y, rect3.w, rect3.h, alpha);
+		} else {
+			if (texMemoria3N1_ && texMemoria3N2_ && texMemoria3N3_) {
+				float t = memoryHoverTimers_[2];
+				float a1 = 255.0f, a2 = 0.0f, a3 = 0.0f;
+				if (t > 0.0f)
+				{
+					if (t <= 1.0f) {
+						a1 = (1.0f - t) * 255.0f;
+						a2 = t * 255.0f;
+						a3 = 0.0f;
+					}
+					else if (t <= 2.0f) {
+						float progress = t - 1.0f;
+						a1 = 0.0f;
+						a2 = (1.0f - progress) * 255.0f;
+						a3 = progress * 255.0f;
+					}
+					else if (t <= 3.0f) {
+						float progress = t - 2.0f;
+						a1 = progress * 255.0f;
+						a2 = 0.0f;
+						a3 = (1.0f - progress) * 255.0f;
+					}
 				}
-				else if (t <= 2.0f) {
-					float progress = t - 1.0f;
-					a1 = 0.0f;
-					a2 = (1.0f - progress) * 255.0f;
-					a3 = progress * 255.0f;
-				}
-				else if (t <= 3.0f) {
-					float progress = t - 2.0f;
-					a1 = progress * 255.0f;
-					a2 = 0.0f;
-					a3 = (1.0f - progress) * 255.0f;
-				}
-			}
 
-			if (a1 > 0) render.DrawTextureAlphaF(texMemoria3N1_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a1);
-			if (a2 > 0) render.DrawTextureAlphaF(texMemoria3N2_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a2);
-			if (a3 > 0) render.DrawTextureAlphaF(texMemoria3N3_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a3);
-		} else if (hover3) {
-			SDL_Rect r3 = { (int)rect3.x, (int)rect3.y, (int)rect3.w, (int)rect3.h };
-			render.DrawRectangle(r3, 255, 255, 255, 60, false, false);
+				if (a1 > 0) render.DrawTextureAlphaF(texMemoria3N1_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a1);
+				if (a2 > 0) render.DrawTextureAlphaF(texMemoria3N2_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a2);
+				if (a3 > 0) render.DrawTextureAlphaF(texMemoria3N3_, rect3.x, rect3.y, rect3.w, rect3.h, (Uint8)a3);
+			} else if (hover3) {
+				SDL_Rect r3 = { (int)rect3.x, (int)rect3.y, (int)rect3.w, (int)rect3.h };
+				render.DrawRectangle(r3, 255, 255, 255, 60, false, false);
+			}
 		}
 	}
 
@@ -5481,6 +5533,13 @@ void Scene::ExecuteSubMapLoad()
 {
 
     int savedHealth = player ? player->health : 3;
+    bool savedBlanket = player ? player->HasBlanket() : false;
+    bool savedSlingshot = player ? player->HasSlingshot() : false;
+    bool savedStuffedAnimal = player ? player->HasStuffedAnimal() : false;
+    bool savedFragments[3] = {false, false, false};
+    if (player) {
+        for(int i = 0; i < 3; i++) savedFragments[i] = player->HasMemoryFragment(i);
+    }
 
     player.reset();
 
@@ -5523,8 +5582,14 @@ void Scene::ExecuteSubMapLoad()
         if (savedHealth > healthSlotCount_) {
             savedHealth = healthSlotCount_;
         }
+        player->health = savedHealth;
+        player->SetHasBlanket(savedBlanket);
+        player->SetHasSlingshot(savedSlingshot);
+        player->SetHasStuffedAnimal(savedStuffedAnimal);
+        for(int i = 0; i < 3; i++) {
+            player->SetMemoryFragment(i, savedFragments[i]);
+        }
     }
-    player->health = savedHealth;
 
     float spawnX = 0.0f, spawnY = 0.0f;
 	if (Engine::GetInstance().map->GetSpawnById(subMapSpawnId_, spawnX, spawnY))


### PR DESCRIPTION
Implements collectible memory fragments: adds fragment_id map property and reads it when spawning MemoryFragment entities. MemoryFragment notifies Player on collect; Player gains arrays to track collected/new fragments. SaveSystem persists hasMemoryFragment[0..2] to XML and restores them (new flags cleared on load). Scene: stores fragment persistence across map loads, loads/unloads collected variant textures, draws collected/new animations in the inventory, shows fragment markers on the minimap, and preserves fragment state during submap loads/unloads. Minor UI tweak (inventory portrait vertical offset) and initialization of timers/texture pointers included. MapTemplate.tmx updated with a default fragment_id property.

## Canvis
<!-- Descripció breu dels canvis -->

## Issues relacionades
<!-- Closes #XX -->

## Tipus de canvi
- [ ] `feat`: Nova funcionalitat
- [ ] `fix`: Correcció de bug
- [ ] `art`: Asset gràfic
- [ ] `docs`: Documentació
- [ ] `refactor`: Refactorització de codi
- [ ] `build`: Canvis al sistema de build

## Checklist
- [ ] El codi compila sense errors
- [ ] He provat els canvis localment
- [ ] He seguit les naming conventions (PascalCase classes, camelCase mètodes, m_ membres)
- [ ] He usat Conventional Commits al títol del PR
- [ ] He enllaçat la Issue corresponent
